### PR TITLE
Avoid invoking ssh-agent and adding a key to it in favor of telling ssh where to find the private key.

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-eval "$(ssh-agent -s)" # Start ssh-agent cache
 chmod 600 /tmp/deploy_rsa # Allow read access to the private key
-ssh-add /tmp/deploy_rsa # Add the private key to SSH
-ssh cubing@$WCA_HOST worldcubeassociation.org/scripts/deploy.sh update_docs
+ssh -i /tmp/deploy_rsa cubing@$WCA_HOST worldcubeassociation.org/scripts/deploy.sh update_docs


### PR DESCRIPTION
This feels a little simpler to me. Hopefully it works!