### PR TITLE
Add Code of Ethics managed by WEC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @thewca/software-team
 documents/ @thewca/board
+documents/Code\ of\ Ethics.md @thewca/wec


### PR DESCRIPTION
I believe that's all we need to let this file be built automatically.
Once there is an actual content we can modify the WCA `/documents` page to link to it.