### PR TITLE
[MotionAmendments-January2020] Delegates

### DIFF
--- a/documents/motions/08.2020.1 - Delegates.md
+++ b/documents/motions/08.2020.1 - Delegates.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 8.2019.1  
+**Motion number:** 8.2020.1  
 **Subject:** WCA Delegates  
 **Intent:** Procedure of acknowledgement of WCA Delegates and description of their rights and duties  
 **Submitted by:** Board of Directors  
-**Date:** January 1, 2019  
+**Date:** January 31, 2020 
 
 # Motion
 
@@ -15,16 +15,16 @@ WCA Delegate is a role defined in the WCA Regulations to oversee official WCA Co
 3. WCA Competitions and WCA Competition results can only be officially acknowledged by the WCA if a WCA Delegate is present and overseeing the competition.
    1. Exception: in case the WCA Delegate cannot attend the competition, the WCA Board may appoint a trusted person to act as a temporary WCA Candidate Delegate for the competition.
 4. Rights of WCA Delegates
-   1. WCA Delegates have the right to make a WCA Competition official after the approval of the WCA Board.
+   1. WCA Delegates have the right to make a WCA Competition official after the approval of the WCA Competition Announcement Team.
    2. For WCA Competitions that they are overseeing, WCA Delegates have the rights as described in the WCA Regulations.
 5. Duties of WCA Delegates
-   1. WCA Delegates shall behave as a representative of the WCA in accordance with the Mission, Spirit, and Regulations of the WCA.
+   1. WCA Delegates shall behave as a representative of the WCA in accordance with the Mission, Spirit, Regulations, Policies, and Code of Ethics of the WCA.
    2. WCA Delegates shall be involved in their local community and make sure the voice of their local community is heard within the WCA.
    3. WCA Delegates shall be actively involved in the community of WCA Delegates.
    4. WCA Delegates shall sustain knowledge and skills regarding the Mission, Spirit, and Regulations of the WCA.
    5. WCA Delegates shall manage relationships with Regional Organizations, Competition Organizers, and Competition Staff.
    6. WCA Delegates shall develop capabilities of Regional Organizations, Competition Organizers, and Competition Staff.
-   7. WCA Delegates shall accept and comply with decisions of the WCA Board and the WCA Officers.
+   7. WCA Delegates shall accept and comply with decisions of the WCA Board, WCA Officers, and WCA Teams/Committees.
    8. For every WCA Competition that they are overseeing, WCA Delegates:
       1. represent the WCA
       2. make sure Competition Organizers and Competition Staff are fully capable, equipped, and prepared to make the competition successful
@@ -52,7 +52,7 @@ WCA Delegate is a role defined in the WCA Regulations to oversee official WCA Co
    1. Full Delegates are Staff of the WCA who have been appointed by the WCA to perform the role of WCA Delegate.
 9. Candidate Delegates
    1. Candidate Delegates are Staff of the WCA who have been appointed by the WCA to perform the role of WCA Delegate.
-   2. Candidate Delegates will require a time period of extra attention by Senior Delegates, to support their development to Full Delegates and Staff of the WCA.
+   2. Candidate Delegates will require a time period of extra attention by Senior Delegates, to support their development to Full Delegates of the WCA.
       1. After a Candidate Delegate has held the position for at least one year and has successfully managed at least three WCA Competitions, a Senior Delegate may give a Candidate Delegate the status of Full Delegate, if the Senior Delegate judges that the Candidate Delegate has shown their fitness for the position.
       2. To promote a Candidate Delegate to Full Delegate, the Senior Delegate must submit the corresponding application to the WCA Board.
       3. The WCA Board rejects or approves the application.


### PR DESCRIPTION
Fixes #126 

Updated Motion to say that competitions are announced by WCAT
Removed unnecessary mention of Candidate Delegates becoming Staff
Updates the Motion to explicitly require Delegates to adhere to Policies and Code of Ethics,