### PR TITLE
WCRP version 1.1

### DIFF
--- a/documents/policies/external/Competition Requirements.md
+++ b/documents/policies/external/Competition Requirements.md
@@ -1,6 +1,6 @@
 # WCA Competition Requirements Policy
 <div class="version">
-### Version 1.0
+### Version 1.1
 </div>
 
 ## Purpose
@@ -20,7 +20,7 @@ An official WCA Competition must:
 7. Have at least one competitor.
 8. Have at least one designated WCA Delegate in attendance.
    1. Exception: in case the WCA Delegate cannot attend the competition, the WCA Board may
-appoint a trusted person to act as a temporary WCA Candidate Delegate for the
+appoint a trusted person to act as a temporary WCA Delegate for the
 competition.
    2. The WCA Delegate for a competition is responsible for:
       1. Submitting the Delegate Report to the WCA Regulations Committee and the WCA Quality Assurance Committee regarding adherence to WCA Regulations and quality standards during the competition, the overall course of the competition, and any incidents that happened. The report must be submitted within one week of the end of the competition.


### PR DESCRIPTION
Candidate Delegates have been renamed to Junior Delegates. The type of Delegate role in these cases is not necessary in temporary cases as Candidate (now Junior) Delegates and Full Delegates have the same rights and duties at competitions.