### PR TITLE
Allow Restriction-less Competitions

### DIFF
--- a/documents/policies/external/Competition Safety.md
+++ b/documents/policies/external/Competition Safety.md
@@ -27,6 +27,7 @@ In order for a competition to be approved and sanctioned by the WCA the WCA Dele
 
 The Board of Directors retains the right to require other conditions to be met in order for a competition to be recognized and sanctioned by the WCA. Additionally the Board has the right at any time to withdraw approval and cancel a competition where it may no longer be possible to hold safely
 
+The recommendations set forth in this policy may be waived at the discretion of the WCA Board, if community transmissions are near-zero within the region the competition serves and the competition abides by all local government advice. 
 
 ### Holding of competitions
 In addition to the above section on requirements for return to competitions, the following are recommendations in place for organizers who have the approval of the Board to continue with their competitions:

--- a/documents/policies/external/Competition Safety.md
+++ b/documents/policies/external/Competition Safety.md
@@ -1,6 +1,6 @@
 # WCA Competition Safety Policy
 <div class="version">
-### Version 1.3
+### Version 1.4
 </div>
 
 ## Purpose


### PR DESCRIPTION
Allow competitions to be run without following the recommendations within the WCA Competition Safety Policy

Awaiting Board vote before merging