### PR TITLE
Allow UTF-8 symbols in edudoc headers

### DIFF
--- a/assets/edudoc-header.html
+++ b/assets/edudoc-header.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
-<head></head>
+<head>
+    <meta charset="utf-8"/>
+</head>
 <body>
 <div style="border-bottom:1px solid black; text-align:center; width:100%; height:100%">
     <div style="float:left; text-align:left">DOCUMENT_TITLE</div>


### PR DESCRIPTION
With the recently introduced Swedish translation #226 the `ö` and `ä` symbols were displayed incorrectly. This commit should fix such errors by allowing UTF-8 symbols in the header HTML