### PR TITLE
Added the competition templates section to edudoc

### DIFF
--- a/edudoc/competition-templates/README.md
+++ b/edudoc/competition-templates/README.md
@@ -1,0 +1,44 @@
+# WCA Competition Templates
+
+### DO NOT use any templates before reading this entire document!
+
+In this repo you can find templates for cube covers and clock covers, both of which are stackable; results boxes for scorecards: a design that can be hung on a wall and another that can be put on a table; Square-1 inserts (21 per page) and an outline of some important competition rules.
+
+## Instructions
+
+1. If you would like to use the WCA designs, use the files in the folder for the language used in your region. **WARNING**: Some of the PDF previews might have rendering artifacts, but these won't show up if you download the files. If you would like to make your own custom designs, use the files in the `Editable Files` folder. **DO NOT** make colored clock cover designs, they must be in black and white (BW).
+
+2. The designs for clock covers and competition rules can be printed on a home printer; the clock covers need to be printed in BW and the competition rules need to be printed in color. The other designs **MUST** be printed using an industry-grade printer, so you will have to find a printing place in your area. They will require `.PDF` files to make your prints.
+
+3. If you are making **custom clock covers**, you will need to copy your finished design to a new A4-sized document (210\*297mm / 8.27\*11.69in), rotate the whole design 12 degrees counterclockwise and save the file as PDF. If you are printing them on a regular office printer that can’t print all the way to the edges, try selecting the setting “fit to printable area”.
+
+4. Make sure you print all templates **STRICTLY** within the following specifications (**covers printed using different specifications can be unfit for WCA competitions to the extent of some results being removed afterwards**):
+
+| Template            | Paper size | Paper thickness | Paper type |
+| ------------------- | :--------: | :-------------- | :--------- |
+| Cube cover          |     A3     | 350-400 gsm \*  | Color      |
+| Clock cover \*\*    |     A4     | 60-90 gsm       | BW         |
+| Results box (table) |     A3     | 350-400 gsm     | Color      |
+| Results box (wall)  |     A4     | 250-350 gsm     | Color      |
+| Square-1 inserts    |     A4     | 250-350 gsm     | Color      |
+| Competition rules   |     A4     | any             | Color      |
+
+\* "gsm" stands for grams per square meter. This is the standard unit of measurement for paper thickness.
+
+\*\* Clock covers are printed on standard printing paper used in regular BW office printers.
+
+5. You will need the following tools in order to assemble the prints:
+
+-   Scissors
+-   Ruler
+-   Paper glue (only for clock covers)
+-   Double-sided tape up to 1cm in width (only for results boxes and cube covers)
+-   Blade (knife, box cutter, etc.) (only for results boxes and cube covers)
+
+6. On all templates except for the clock covers, make all cuts on the **INNER** side of the black lines, leaving no black color visible after the cuts are done. On the clock cover the cuts need to be made **THROUGH** the black lines.
+
+7. Link to the templates folder (**please only share the link to THIS page and not the direct link to the folder**): [Templates Folder](https://drive.google.com/drive/folders/1EVqEWSqruZ8_vEJpUmqhFUqaikzgUkkP?usp=sharing)
+
+## Credits
+
+Made by Deni Mintsaev. Competition rules image made by Tom Nelson.


### PR DESCRIPTION
I've created various competition templates that organizers could use. This includes cube covers, clock covers, results boxes, competition rules and square-1 inserts. There are editable files and also ready-to-print pdf files in English and Russian. The folder only includes the README file, but this file links to a WQAC google drive folder that contains all of the templates.