### PR TITLE
Added the competition templates section to edudoc (v2)

### DIFF
--- a/edudoc/competition-templates/README.md
+++ b/edudoc/competition-templates/README.md
@@ -1,0 +1,44 @@
+# WCA Competition Templates
+
+### DO NOT use any templates before reading this entire document!
+
+In this repo you can find templates for cube covers and clock covers, both of which are stackable; results boxes for scorecards: a design that can be hung on a wall and another that can be put on a table; Square-1 inserts (21 per page) and an outline of some important competition rules.
+
+## Instructions
+
+1. If you would like to use the WCA designs, use the files in the folder for the language used in your region. **WARNING**: Some of the PDF previews might have rendering artifacts, but these won't show up if you download the files. If you would like to make your own custom designs, use the files in the `Editable Files` folder. **DO NOT** make colored clock cover designs, they must be in black and white (BW).
+
+2. The designs for clock covers and competition rules can be printed on a home printer; the clock covers need to be printed in BW and the competition rules need to be printed in color. The other designs **MUST** be printed using an industry-grade printer, so you will have to find a printing place in your area. They will require `.PDF` files to make your prints.
+
+3. If you are making **custom clock covers**, you will need to copy your finished design to a new A4-sized document (210\*297mm / 8.27\*11.69in), rotate the whole design 12 degrees counterclockwise and save the file as PDF. If you are printing them on a regular office printer that can’t print all the way to the edges, try selecting the setting “fit to printable area”.
+
+4. Make sure you print all templates **STRICTLY** within the following specifications (**covers printed using different specifications can be unfit for WCA competitions to the extent of some results being removed afterwards**):
+
+| Template            | Paper size | Paper thickness | Paper type |
+| ------------------- | :--------: | :-------------- | :--------- |
+| Cube cover          |     A3     | 350-400 gsm \*  | Color      |
+| Clock cover \*\*    |     A4     | 60-90 gsm       | BW         |
+| Results box (table) |     A3     | 350-400 gsm     | Color      |
+| Results box (wall)  |     A4     | 250-350 gsm     | Color      |
+| Square-1 inserts    |     A4     | 250-350 gsm     | Color      |
+| Competition rules   |     A4     | any             | Color      |
+
+\* "gsm" stands for grams per square meter. This is the standard unit of measurement for paper thickness.
+
+\*\* Clock covers are printed on standard printing paper used in regular BW office printers.
+
+5. You will need the following tools in order to assemble the prints:
+
+-   Scissors
+-   Ruler
+-   Paper glue (only for clock covers)
+-   Double-sided tape up to 1cm in width (only for results boxes and cube covers)
+-   Blade (knife, box cutter, etc.) (only for results boxes and cube covers)
+
+6. On all templates except for the clock covers, make all cuts on the **INNER** side of the black lines, leaving no black color visible after the cuts are done. On the clock cover the cuts need to be made **THROUGH** the black lines.
+
+7. Link to the templates folder (**please only share the link to THIS page and not the direct link to the folder**): [Templates Folder](https://drive.google.com/drive/folders/1EVqEWSqruZ8_vEJpUmqhFUqaikzgUkkP?usp=sharing)
+
+## Credits
+
+Made by Deni Mintsaev. Competition rules image made by Tom Nelson.

--- a/edudoc/competition-templates/README.md
+++ b/edudoc/competition-templates/README.md
@@ -1,33 +1,48 @@
 # WCA Competition Templates
 
+::::: {.box .important}
+
 ### DO NOT use any templates before reading this entire document!
 
-In this repo you can find templates for cube covers and clock covers, both of which are stackable; results boxes for scorecards: a design that can be hung on a wall and another that can be put on a table; Square-1 inserts (21 per page) and an outline of some important competition rules.
+:::::
+
+Here you can find printable templates for cube covers and clock covers, both of which are stackable; results boxes for scorecards: a design that can be hung on a wall and another that can be put on a table; Square-1 inserts (21 per page) and an outline of some important competition rules. There are also two 3D-printable clock cover designs.
 
 ## Instructions
 
-1. If you would like to use the WCA designs, use the files in the folder for the language used in your region. **WARNING**: Some of the PDF previews might have rendering artifacts, but these won't show up if you download the files. If you would like to make your own custom designs, use the files in the `Editable Files` folder. **DO NOT** make colored clock cover designs, they must be in black and white (BW).
+1. If you would like to use the WCA designs, use the files in the folder for the language used in your region. **WARNING: Some of the PDF previews might have rendering artifacts, but these won't show up if you download the files.** If you would like to make custom designs, use the files in the `Editable Files` folder. **DO NOT** make colored clock cover designs, they must be in black and white (BW).
 
-2. The designs for clock covers and competition rules can be printed on a home printer; the clock covers need to be printed in BW and the competition rules need to be printed in color. The other designs **MUST** be printed using an industry-grade printer, so you will have to find a printing place in your area. They will require `.PDF` files to make your prints.
+2. The designs for paper clock covers and competition rules can be printed on a home printer; the clock covers need to be printed in BW and the competition rules need to be printed in color. The other designs **MUST** be printed using an industry-grade printer, so you will have to find a printing place in your area. They will require `.PDF` files to make your prints.
 
 3. If you are making **custom clock covers**, you will need to copy your finished design to a new A4-sized document (210\*297mm / 8.27\*11.69in), rotate the whole design 12 degrees counterclockwise and save the file as PDF. If you are printing them on a regular office printer that can’t print all the way to the edges, try selecting the setting “fit to printable area”.
 
-4. Make sure you print all templates **STRICTLY** within the following specifications (**covers printed using different specifications can be unfit for WCA competitions to the extent of some results being removed afterwards**):
+4. There are two 3D-printable clock cover designs: one made by Mitchell Lane and one made by Cady Shields. Mitchell's version can stack, but doesn't fit the Angstrom clock. Cady's design does not stack, but is more sturdy and fits the Angstrom clock. These 3D clock cover designs last much longer than the paper versions. We recommend that you look for a 3D printing service in your area or try to find a 3D printing enthusiast who could make them for you. If you live in the US and would like to have some 3D clock covers printed, you can contact Mitchell Lane directly: mlane@worldcubeassociation.org
 
-| Template            | Paper size | Paper thickness | Paper type |
-| ------------------- | :--------: | :-------------- | :--------- |
-| Cube cover          |     A3     | 350-400 gsm \*  | Color      |
-| Clock cover \*\*    |     A4     | 60-90 gsm       | BW         |
-| Results box (table) |     A3     | 350-400 gsm     | Color      |
-| Results box (wall)  |     A4     | 250-350 gsm     | Color      |
-| Square-1 inserts    |     A4     | 250-350 gsm     | Color      |
-| Competition rules   |     A4     | any             | Color      |
+5. Make sure you print all templates **STRICTLY** within the following specifications (**covers printed using different specifications can be unfit for WCA competitions to the extent of some results being removed afterwards**):
+
+| Template               | Paper size | Paper thickness    | Paper type |
+| ---------------------- | :--------: | :----------------- | :--------- |
+| Cube cover             |     A3     | 350-400 gsm \*     | Color      |
+| Paper clock cover \*\* |     A4     | 60-90 gsm          | BW         |
+| Results box (table)    |     A3     | 350-400 gsm        | Color      |
+| Results box (wall)     |     A4     | 250-350 gsm \*\*\* | Color      |
+| Square-1 inserts       |     A4     | 250-350 gsm        | Color      |
+| Competition rules      |     A4     | Any                | Color      |
 
 \* "gsm" stands for grams per square meter. This is the standard unit of measurement for paper thickness.
 
 \*\* Clock covers are printed on standard printing paper used in regular BW office printers.
 
-5. You will need the following tools in order to assemble the prints:
+\*\*\* Thicker is better.
+
+| Template                           | Resolution  | Infill | Filament | Rafts | Supports |
+| ---------------------------------- | :---------: | :----: | :------: | :---: | :------: |
+| 3D clock cover (Cady's design)     | 0.2 - 0.3mm |  15%   |   PLA    |  Any  | None \*  |
+| 3D clock cover (Mitchell's design) |     Any     |  Any   |   Any    |  Any  |   Any    |
+
+\* None are needed when printing upright.
+
+6. You will need the following tools in order to assemble the paper prints:
 
 -   Scissors
 -   Ruler
@@ -35,10 +50,15 @@ In this repo you can find templates for cube covers and clock covers, both of wh
 -   Double-sided tape up to 1cm in width (only for results boxes and cube covers)
 -   Blade (knife, box cutter, etc.) (only for results boxes and cube covers)
 
-6. On all templates except for the clock covers, make all cuts on the **INNER** side of the black lines, leaving no black color visible after the cuts are done. On the clock cover the cuts need to be made **THROUGH** the black lines.
+7. On all templates except for the clock covers, make all cuts on the **INNER** side of the black lines, leaving no black color visible after the cuts are done. On the clock cover the cuts need to be made **THROUGH** the black lines.
 
-7. Link to the templates folder (**please only share the link to THIS page and not the direct link to the folder**): [Templates Folder](https://drive.google.com/drive/folders/1EVqEWSqruZ8_vEJpUmqhFUqaikzgUkkP?usp=sharing)
+::::: {.box .important}
+Link to the templates folder (**please only share the link to THIS page and not the direct link to the folder**): [Templates Folder](https://drive.google.com/drive/folders/1EVqEWSqruZ8_vEJpUmqhFUqaikzgUkkP?usp=sharing)
+:::::
 
 ## Credits
 
-Made by Deni Mintsaev. Competition rules image made by Tom Nelson.
+Paper templates - Deni Mintsaev
+3D clock cover - Cady Shields
+Stackable 3D clock cover - Mitchell Lane
+Competition rules image - Tom Nelson


### PR DESCRIPTION
I've created various competition templates that organizers could use. This includes cube covers, clock covers, results boxes, competition rules and square-1 inserts. There are editable files and also ready-to-print PDF files in English and Russian. There are also two 3D-printable clock cover designs: one made by Mitchell Lane and one made by Cady Shields. The folder only includes the README file, but this file links to a WQAC google drive folder that contains all of the templates.