### PR TITLE
Create an artifact with the build folder on PR

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,3 +16,8 @@ jobs:
 
       - name: Run the PDF compilation process
         run: bin/build.sh
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build
+          path: build


### PR DESCRIPTION
Currently the only way to see what would result in the `build` branch of this repository is to build locally.
I think it would be nice to also have the resulting `build` folder from a pull request, before having to deploy it, and without having to manually create it (and also because the person manually checking it may do something a little different from what the CI does).

The easy way to solve that is simply to upload the build folder as an artifact at the end of the PR workflow.