### PR TITLE
Fix spelling errors/typos

### DIFF
--- a/edudoc/competitor-tutorial/tutorial.md
+++ b/edudoc/competitor-tutorial/tutorial.md
@@ -48,7 +48,7 @@ It can look like any of the three versions below.
 ![](images/cover.jpg){.centered height=200px}
 :::::
 
-- **Score sheet**: After a puzzle is scrambled, the scrambler signs for the correctnees on the score sheet. Additonally after each solve the judge writes down the result on the score sheet, signs it and has the competitor sign it, to acknowledge that the result is
+- **Score sheet**: After a puzzle is scrambled, the scrambler signs for the correctness on the score sheet. Additionally after each solve the judge writes down the result on the score sheet, signs it and has the competitor sign it, to acknowledge that the result is
   - 1) correct
   - 2) complete,
   - 3) properly formatted, and

--- a/edudoc/delegate-crash-course/delegate_crash_course.md
+++ b/edudoc/delegate-crash-course/delegate_crash_course.md
@@ -261,7 +261,7 @@ Final remark: the rules for competitor names described in the Administering regi
 *(updated on March 1, 2019)*
 
 We believe that reports are a valuable learning opportunity for new Delegates and therefore ask for them to be sent to the Delegates’ mailing list. Since all Board members are in said mailing list, this complies with regulation 1c1). Competition reports must filled out and submitted via the WCA website within one week of the competition. The link to the competition report form is: [https://www.worldcubeassociation.org/competitions/YOUR-COMPETITION-ID/report](https://www.worldcubeassociation.org/competitions/YOUR-COMPETITION-ID/report) where you replace YOUR-COMPETITION-ID with the ID of your competition. You can also easily access the form over the "My competitions" page.\
-This form sends an email to [reports@worldcubeassociation.org](malto:reports@worldcubeassociation.org) with the competition report.\
+This form sends an email to [reports@worldcubeassociation.org](mailto:reports@worldcubeassociation.org) with the competition report.\
 We encourage Delegates to write careful, detailed reports for the benefit of all Delegates, and we also encourage new Delegates to read other Delegates' reports carefully and make the most of this learning opportunity.
 
 ## Paying competition Dues
@@ -277,7 +277,7 @@ Please note, due to limitations with the software, **only the first listed Deleg
 
 As the invoice contact, it is your duty to inform other Delegates for the competition about the invoice being owed, and also to communicate with the WFC on behalf of this invoice. This person may also send the invoice onto the organisation team, another Delegate, an association treasurer, etc. If forwarding onto someone else to pay, we would highly recommend requesting confirmation from them once payment has been made. There is a payment period of 30 days, invoices must be paid within this timeframe otherwise there may be repercussions.
 
-If you ever have any doubts, questions, etc. then feel free to send an email to [finance@worldcubeassociation.org](malto:finance@worldcubeassociation.org) who will get back to you as soon as possible.
+If you ever have any doubts, questions, etc. then feel free to send an email to [finance@worldcubeassociation.org](mailto:finance@worldcubeassociation.org) who will get back to you as soon as possible.
 
 ## Administering WCA user accounts
 *(updated on November 10th, 2019)*

--- a/edudoc/organizer-guidelines/work-during-comp.md
+++ b/edudoc/organizer-guidelines/work-during-comp.md
@@ -42,7 +42,7 @@ Depending on who the owner is, or if issues arise, someone needs to be responsib
 
 ## Calling Volunteers
 
-One of the tasks for the organizers is calling volunteers (scramblers, judges, and possibly runners) for each group and making sure the group proceeds according to plan. The organizers need to always check if all the needed judging stations have judges. They also need to pay attention to whether all scramblers are in place and, if in use, the needed number of runners is present. If you are assigning duties, you can print out an overview of who is scramblind/judging/running for each group so you can quickly find them during the competition. If someone who is assigned to judge or scramble refuses to fulfill their task or is missing, notify your Delegate(s) of this and they will handle the case.
+One of the tasks for the organizers is calling volunteers (scramblers, judges, and possibly runners) for each group and making sure the group proceeds according to plan. The organizers need to always check if all the needed judging stations have judges. They also need to pay attention to whether all scramblers are in place and, if in use, the needed number of runners is present. If you are assigning duties, you can print out an overview of who is scrambling/judging/running for each group so you can quickly find them during the competition. If someone who is assigned to judge or scramble refuses to fulfill their task or is missing, notify your Delegate(s) of this and they will handle the case.
 
 ## Calling groups
 


### PR DESCRIPTION
- Fixes spelling errors in Competitor Tutorial and Organizer Guidelines
- Fixes typo in Delegate Crash Course (`malto` vs `mailto`)