### PR TITLE
Fixing section references

### DIFF
--- a/documents/WCA Bylaws.md
+++ b/documents/WCA Bylaws.md
@@ -50,10 +50,10 @@ Associate Regional Organization membership is available for groups who act to or
 This membership is active from the moment they are acknowledged by the Board of Directors as meeting the requirements for this category and continues until this membership is revoked either through resignation or termination or after two years from the date in which their membership is active. This category of members do not have the right to vote in matters of the WCA and any elections.
 
 ### 2.5 Individual Voting Members
-Any individual who is currently a Full Delegate, Committee/Team Leader, Committee/Team Senior Member, Director or Officer is automatically considered an individual voting member of the WCA. This membership is active from the moment an individual is promoted to one of the above positions and continues until this membership is revoked either through resignation or termination (see 2.6 and 2.8). This category of members have the right to place a maximum of one vote in matters of the WCA and any elections.
+Any individual who is currently a Full Delegate, Committee/Team Leader, Committee/Team Senior Member, Director or Officer is automatically considered an individual voting member of the WCA. This membership is active from the moment an individual is promoted to one of the above positions and continues until this membership is revoked either through resignation or termination (see 2.9). This category of members have the right to place a maximum of one vote in matters of the WCA and any elections.
 
 ### 2.6 Individual Non-voting Members
-Any individual who has competed at a past WCA Competition and has an attributed personal WCA ID is automatically considered an individual non-voting member of the WCA. This membership type is active from the moment an individual starts their first official attempt at their first WCA competition and continues until this membership is revoked either through resignation or termination (see 2.6 and 2.8). This category of members does not have the right to vote in matters of the WCA and any elections.
+Any individual who has competed at a past WCA Competition and has an attributed personal WCA ID is automatically considered an individual non-voting member of the WCA. This membership type is active from the moment an individual starts their first official attempt at their first WCA competition and continues until this membership is revoked either through resignation or termination (see 2.9). This category of members does not have the right to vote in matters of the WCA and any elections.
 
 ### 2.7 Annual Dues
 The amount required for annual dues shall be $0 each year for all membership types, unless changed by a majority vote of the members at a properly announced meeting. Continued membership is contingent upon being up-to-date on membership dues.
@@ -238,7 +238,7 @@ Unless otherwise provided in these Bylaws, and subject to any guidelines and pro
 
 ## 9. Gifts, Grants, and Contracts {.page-break-before}
 ### 9.1 Gifts
-The Board or its designee may accept on behalf of the WCA any contribution, gift, bequest, or device for the charitable purposes of the WCA. Any officer or director who receives any contribution, gift, bequest, or device from any entity the WCA engages with in the past, present, or future shall be considered an interested party for the purposes of the Conflict of Interest policy (3.10).
+The Board or its designee may accept on behalf of the WCA any contribution, gift, bequest, or device for the charitable purposes of the WCA. Any officer or director who receives any contribution, gift, bequest, or device from any entity the WCA engages with in the past, present, or future shall be considered an interested party for the purposes of the Conflict of Interest policy (3.11).
 
 ### 9.2 Grants
 The Board shall exercise itself, or delegate, subject to its supervision, control over grants, contributions, and other financial assistance provided by the WCA, including, without limitation, those made in connection with fiscal sponsorship relationships.


### PR DESCRIPTION
Some of the references to other sections of the Bylaws are incorrect (presumably outdated). I have updated them with the sections I believe they are now supposed to direct to (it should be obvious).