### PR TITLE
Allow clerical Motions fixes from the Board

### DIFF
--- a/documents/motions/13.2022.1 - Amendments of Motions.md
+++ b/documents/motions/13.2022.1 - Amendments of Motions.md
@@ -1,10 +1,10 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 13.2021.1  
+**Motion number:** 13.2022.1  
 **Subject:** Amendments of Motions  
 **Intent:** Definition of the Amendment Procedure of the Motions  
 **Submitted by:** WCA Board  
-**Date:** February 28, 2021  
+**Date:** May 1, 2022  
 
 # Motion
 
@@ -26,3 +26,4 @@
       3. If the WCA Voting Members do not approve the Motions, the process will stop.
    8. The approved Motions and Amendments of the Motions must be announced and made publicly accessible via the online services of the WCA.
    9. The WCA Board shall register the approved Motions with the legal parties.
+3. The Board may vote to approve fixes to clerical errors without the need for a full Motions amendment as outlined above.


### PR DESCRIPTION
To avoid Motions updates containing typo/grammar/link fixes in future.