### PR TITLE
Clarify Trainee as default appointment

### DIFF
--- a/documents/motions/08.2022.2 - Trainee Delegates.md
+++ b/documents/motions/08.2022.2 - Trainee Delegates.md
@@ -1,17 +1,17 @@
 # SUBMISSION OF PROPOSED MOTION
 
-**Motion number:** 8.2021.2  
+**Motion number:** 8.2022.2  
 **Subject:** WCA Trainee Delegates  
 **Intent:** Procedure of acknowledgement of WCA Trainee Delegates and description of their rights and duties  
 **Submitted by:** WCA Board  
-**Date:** February 28, 2021  
+**Date:** May 1, 2022  
 
 # Motion
 
 Trainee Delegates are Community Members who have been appointed by the WCA to train for the role of WCA Delegate.
 
-1. Trainee Delegates will require a time period of extra mentoring and assistance by Senior Delegates and/or Regional Delegates, to support their development to Junior Delegates and Staff of the WCA.
-   1. A Senior Delegate may nominate a Trainee Delegate for a promotion to Junior Delegate, if the Senior Delegate judges that the Trainee Delegate has shown their fitness for the position.
+1. Trainee Delegates will require a time period of extra mentoring and assistance by Senior Delegates and/or Regional Delegates, to support their development to Junior Delegates and Staff of the WCA. Trainee Delegate should be the default appointment by a Senior Delegate, unless there is need from the Community to have the appointment be directly to Junior Delegate.
+   1. A Senior Delegate may promote a Trainee Delegate to Junior Delegate, if the Senior Delegate judges that the Trainee Delegate has shown their fitness for the position and the Delegate has Delegated at least one competition.
    2. To promote a Trainee Delegate to Junior Delegate, the Senior Delegate must submit the corresponding application to the WCA Board.
    3. The WCA Board rejects or approves the application.
    4. After approval, the Senior Delegate appoints the person as Junior Delegate.
@@ -19,7 +19,7 @@ Trainee Delegates are Community Members who have been appointed by the WCA to tr
    1. Trainee Delegates have the right to be listed as a Delegate at WCA Competitions in which there is at least one other WCA Delegate listed.
       1. At least one listed Delegate must possess the position of Junior Delegate, Full Delegate, Regional Delegate, or Senior Delegate.
       2. Trainee Delegates have the right to make decisions at competitions in which they are listed as a Delegate.
-      3. Trainee Delegates have the right to read and participate in conversations in the Delegates and Reports groups.
+      3. Trainee Delegates have the right to read and participate in conversations in the Reports group.
       4. Trainee Delegates have the right to contribute to Delegate Reports about competitions that they helped oversee.
       5. Trainee Delegates have the right to review and compile results for competitions they helped oversee.
       6. Trainee Delegates have the right to submit corrections and changes to results of competitions they helped oversee.


### PR DESCRIPTION
Additionally, remove Trainees from Delegates group but keep them in Reports.