### PR TITLE
Fix references/links to Motions

### DIFF
--- a/documents/motions/04.2022.1 - WCA Board.md
+++ b/documents/motions/04.2022.1 - WCA Board.md
@@ -19,12 +19,12 @@ The WCA Board of Directors is the leadership team of the WCA and its highest aut
    6. To represent the WCA in all dealings with other relevant organizations and with media.
    7. To negotiate or oversee the negotiation of all contracts on behalf of the WCA in consultation with the appropriate Committees.
 2. The WCA Board has the following rights:
-   1. To amend the Bylaws and their Motions. Such rights must be exercised in accordance with [WCA Motion : Amendments of Bylaws and Motions](wca{documents/motions/13.2021.1 - Amendments of Motions.pdf}).
-   2. To approve amendments to the Regulations. Such rights must be exercised in accordance with [WCA Motion : Amendments of Regulations](wca{documents/motions/14.2021.1 - Amendments of Regulations.pdf}).
+   1. To amend the Bylaws and their Motions. Such rights must be exercised in accordance with [WCA Motion : Amendments of Bylaws and Motions](wca{documents/motions/13.2022.1 - Amendments of Motions.pdf}).
+   2. To approve amendments to the Regulations. Such rights must be exercised in accordance with [WCA Motion : Amendments of Regulations](wca{documents/motions/14.2022.1 - Amendments of Regulations.pdf}).
    3. To establish and remove Committees or change their duties. Such rights must be exercised in accordance with the Motion relative to every Committee.
-   4. To instate and remove Senior Delegates. Such rights must be exercised in accordance with [WCA Motion : Senior Delegates](wca{documents/motions/09.2021.1 - Senior Delegates.pdf}).
+   4. To instate and remove Senior Delegates. Such rights must be exercised in accordance with [WCA Motion : Senior Delegates](wca{documents/motions/09.2022.1 - Senior Delegates.pdf}).
    5. To instate and remove Regional Delegates. Such rights must be exercised in accordance with [WCA Motion : Regional Delegates](wca{documents/motions/09.2021.2 - Regional Delegates.pdf}).
-   6. To suspend or take other sanctions against Registered Speedcubers and to reinstate Registered Speedcubers that have been suspended. Such rights must be exercised in accordance with [WCA Motion : Suspensions and other Sanctions](wca{documents/motions/15.2021.1 - Suspensions and other Sanctions.pdf}).
+   6. To suspend or take other sanctions against Registered Speedcubers and to reinstate Registered Speedcubers that have been suspended. Such rights must be exercised in accordance with [WCA Motion : Suspensions and other Sanctions](wca{documents/motions/15.2022.1 - Suspensions and other Sanctions.pdf}).
    7. To approve the annual budget proposal of the WCA Financial Committee in accordance with [WCA Motion : Finances](wca{documents/motions/11.2021.1 - Finances.pdf}).
    8. To accept or not accept results of WCA Competitions as official, according to the procedures in the Regulations.
    9. To overrule any decision under control of the WCA, as long as the overruling complies with the WCA Bylaws, their Motions, and the Regulations.

--- a/documents/motions/21.2022.1 - WCA Documents.md
+++ b/documents/motions/21.2022.1 - WCA Documents.md
@@ -18,8 +18,8 @@
 3. In case of any dispute between two translations of the same document the American English version shall prevail
 4. Amendments of WCA Documents:
    1. WCA Bylaws shall be amended by the procedures set out in section 12 of the Bylaws.
-   2. WCA Motions shall be amended by the procedures set out in Motion 13.2021.1 Amendments of Motions.
-   3. WCA Regulations and Guidelines shall be amended by the procedures set out in Motion 14.2021.1 Amendments of Regulations.
+   2. WCA Motions shall be amended by the procedures set out in Motion 13.2022.1 Amendments of Motions.
+   3. WCA Regulations and Guidelines shall be amended by the procedures set out in Motion 14.2022.1 Amendments of Regulations.
    4. WCA Policies shall be amended by a majority vote among the WCA Board.
    5. Other WCA Material shall be amended as necessary with approval of the WCA Board.
 5. Management of WCA Documents:  


### PR DESCRIPTION
Fixes invalid links and references to the Motions. 

As a side question, WCA Documents Motion is the only one where other Motions are just mentioned and not linked, shouldn't it be the same as in other Motions?