### PR TITLE
Changed host to our prod ip

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Trigger website deployment
         env:
-          WCA_HOST: worldcubeassociation.org
+          WCA_HOST: 34.208.140.116
         run: |
           mkdir -p $HOME/.ssh
           echo "${{ secrets.DEPLOY_PRIVATE_KEY }}" > /tmp/deploy_rsa


### PR DESCRIPTION
Changing the Github action to have the prod ip as the new host. Alternatively I could also change the deploy code to use AWS Run command, like in the deploy repo.
Thoughts?