### PR TITLE
Fix Several Links and Build Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Official Documents of the World Cube Association.
 
 Whenever changes are made, GitHub builds PDF files out of each Markdown document, pushes the generated files to the [build branch](https://github.com/thewca/wca-documents/tree/build) and deploys them to the website. Documents in `documents` then become available at `worldcubeassociation.org/documents/[path to doc].pdf`, and documents in `edudoc` become available at `worldcubeassociation.org/edudoc/[path to doc].pdf`. Pre-rendered PDFs are simply copied into `build` during the build process.
 
-Example: `documents/policies/external/Competition Requirements.md` gets converted to PDF and becomes available at `https://www.worldcubeassociation.org/documents/policies/external/Competition Requirements.pdf`.
+Example: `documents/policies/external/Competition Requirements.md` gets converted to PDF and becomes available at `https://documents.worldcubeassociation.org/documents/policies/external/Competition Requirements.pdf`.
 
 ## Scripts
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -4,7 +4,7 @@
 set -x
 
 # WCA url and absolute path to WCA logo file
-wca_url="https://worldcubeassociation.org/"
+wca_url="https://www.worldcubeassociation.org/"
 wca_docs_url="https://documents.worldcubeassociation.org/"
 logo=$(realpath "./assets/WCAlogo_notext.svg")
 # Absolute paths to the stylesheets and the edudoc header

--- a/edudoc/delegate-crash-course/delegate_crash_course.md
+++ b/edudoc/delegate-crash-course/delegate_crash_course.md
@@ -65,11 +65,11 @@ To request an official competition you first need to create a new competition by
 ### Some general rules about requesting a competition:
 
 - The competition must be announced **at least 28 days** before the scheduled start of the competition. You should **submit the competition earlier than this** as a safety measure so that if there is an issue with the competition, then the competition will likely still be announced before the 28-day deadline.
-- The competition must comply with the [Competition Requirements Policy](https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf). This means your competition should be at least 10 kilometers and 5 days away from all other competitions. There can be exceptions made to the Proximity Policy if the Delegate has valid arguments. Examples can be found in the policy.
+- The competition must comply with the [Competition Requirements Policy](https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf). This means your competition should be at least 10 kilometers and 5 days away from all other competitions. There can be exceptions made to the Proximity Policy if the Delegate has valid arguments. Examples can be found in the policy.
 
 ### How to fill out the new competition page: {.page-break-before}
 
-- The name of the competition must follow the [Competition Requirements Policy](https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf). Even if you are choosing a name which is obvious for you why it complies with the policy, you must still give an explanation of the name in the “The reason for the name” field.
+- The name of the competition must follow the [Competition Requirements Policy](https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf). Even if you are choosing a name which is obvious for you why it complies with the policy, you must still give an explanation of the name in the “The reason for the name” field.
   - The competition nickname should be the same as the actual name of the competition if it is 32 or fewer characters with few exceptions. If the name of the competition is over 32 characters, you should pick a nickname which is as close as possible to the actual name. The nickname is only used for display purposes and is what will be shown on the “[Competitions](https://www.worldcubeassociation.org/competitions)” page and in the “[Rankings](https://www.worldcubeassociation.org/results/events.php)” page.
   - The ID should be the same as the name or nickname with few exceptions.
 - When writing the location of the venue, please be sure to write with the correct formatting. The country should not be written in the “City name” field. If you are from a country with subregions/states like the United States, you must write the city name first, and then the state in full. For example, this would look like “Portland, Oregon”, Note: NOT “Portland, OR”.
@@ -93,7 +93,7 @@ After you have followed all the steps and double-checked that everything is corr
 
 A Fewest Moves Simultaneous Competition is a competition taking place in different venues at the same time. At such a competition ONLY 3x3x3 Fewest Moves is held and all competitors get the same scrambles. These competitions are made to make it easier for competitors to compete in a less popular event which is not very regularly held.
 
-There are differences in the [Competition Requirements Policy](https://www.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf) which apply to Fewest Moves Simultaneous Competitions. These competitions can be held as long as:
+There are differences in the [Competition Requirements Policy](https://documents.worldcubeassociation.org/documents/policies/external/Competition%20Requirements.pdf) which apply to Fewest Moves Simultaneous Competitions. These competitions can be held as long as:
 
 - None of the locations are closer than 10 kilometers to a regular competition.
 - There can be made exceptions if both competitions are least 5 days apart, or the other competition must not have 3x3x3 Fewest Moves as an event.
@@ -299,7 +299,7 @@ We encourage Delegates to write careful, detailed reports for the benefit of all
 
 (added on April 10, 2019)
 
-All competitions that are WCA official must (bar some exceptions) pay a small fee as part of the [Dues System](https://www.worldcubeassociation.org/documents/policies/external/Dues%20System.pdf).
+All competitions that are WCA official must (bar some exceptions) pay a small fee as part of the [Dues System](https://documents.worldcubeassociation.org/documents/policies/external/Dues%20System.pdf).
 
 Before the competition, both the Delegates and organisers should be aware of the cost and can therefore budget for an estimated fee that they will be liable to pay once results are uploaded.
 
@@ -370,7 +370,7 @@ The following steps should be completed to appoint a new WCA Delegate:
 
 1. Recommend a person to your Senior and Regional Delegate with a reason for why this person should be a Delegate and why the region needs a Delegate
 1. If the Senior Delegate and Regional Delegate agree, then the Senior Delegate will fill out the application form and submit it to the WCA Board
-1. If the Board approves the application, the Senior Delegate will have the new Trainee Delegate agree to and sign the [Code of Conduct](https://www.worldcubeassociation.org/documents/Code%20of%20Conduct.pdf) and [Code of Ethics](https://www.worldcubeassociation.org/documents/Code%20of%20Ethics.pdf), as well as disclose any potential conflicts of interest
+1. If the Board approves the application, the Senior Delegate will have the new Trainee Delegate agree to and sign the [Code of Conduct](https://documents.worldcubeassociation.org/documents/Code%20of%20Conduct.pdf) and [Code of Ethics](https://documents.worldcubeassociation.org/documents/Code%20of%20Ethics.pdf), as well as disclose any potential conflicts of interest
 1. The Trainee Delegate must add a profile picture to their WCA account, if they do not already have one
 1. The Senior Delegate will then update the new Trainee Delegate's status on the WCA website
 1. The Trainee Delegate must then send a short introduction email to the Board (and their regional delegate mailing list if they want to)

--- a/edudoc/organizer-guidelines/budget.md
+++ b/edudoc/organizer-guidelines/budget.md
@@ -51,4 +51,4 @@ Here’s an example budget that could work for your competition. You need to be 
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/budget.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/budget.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/checklist.md
+++ b/edudoc/organizer-guidelines/checklist.md
@@ -36,5 +36,5 @@ Feel free to download and edit this spreadsheet to suit your personal needs or t
 
 Below you can find translations of this document. Each of these also links to a checklist translated to the same language. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/checklist.pdf) - translated by António Gomes
-- [Español (Spanish)](https://worldcubeassociation.org/edudoc/organizer-guidelines/es/checklist.pdf) - translated by Gennaro Monetti
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/checklist.pdf}) - translated by António Gomes
+- [Español (Spanish)](wcadoc{edudoc/organizer-guidelines/es/checklist.pdf}) - translated by Gennaro Monetti

--- a/edudoc/organizer-guidelines/emails.md
+++ b/edudoc/organizer-guidelines/emails.md
@@ -105,4 +105,4 @@ Organization Team of XX Open 2020
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/emails.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/emails.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/enhancing-experience.md
+++ b/edudoc/organizer-guidelines/enhancing-experience.md
@@ -79,4 +79,4 @@ In order to incentivize competitors to join a dedicated staff, there are several
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/enhancing-experience.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/enhancing-experience.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/finding-venue.md
+++ b/edudoc/organizer-guidelines/finding-venue.md
@@ -90,4 +90,4 @@ On some occasions, you’ll need to maintain frequent communication with the ven
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/finding-venue.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/finding-venue.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/new-competitors.md
+++ b/edudoc/organizer-guidelines/new-competitors.md
@@ -33,4 +33,4 @@ Most of the time, the parents or guardians will have some queries about somethin
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/new-competitors.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/new-competitors.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/orga-team-delegate.md
+++ b/edudoc/organizer-guidelines/orga-team-delegate.md
@@ -33,4 +33,4 @@ If you do not yet have an organization team but you have a venue, contacting a D
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/orga-team-delegate.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/orga-team-delegate.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/reflection.md
+++ b/edudoc/organizer-guidelines/reflection.md
@@ -50,4 +50,4 @@ Here are some questions that you should try to get an answer to:
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/reflection.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/reflection.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/registration.md
+++ b/edudoc/organizer-guidelines/registration.md
@@ -34,4 +34,4 @@ For more information on how registrations should be handled, see the [WCA Compet
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/registration.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/registration.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/running-systems.md
+++ b/edudoc/organizer-guidelines/running-systems.md
@@ -53,4 +53,4 @@ A lot of factors play into the chosen system for a competition: A lack of staff,
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/running-systems.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/running-systems.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/schedule.md
+++ b/edudoc/organizer-guidelines/schedule.md
@@ -83,4 +83,4 @@ Keep in mind that any changes to the schedule must be notified to all competitor
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/schedule.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/schedule.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/staff.md
+++ b/edudoc/organizer-guidelines/staff.md
@@ -47,4 +47,4 @@ Most of the time there will not be any major issue to assign staff for the first
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/staff.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/staff.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/venue-setup.md
+++ b/edudoc/organizer-guidelines/venue-setup.md
@@ -47,4 +47,4 @@ For 3x3x3 Fewest Moves, you may have more competitors per station compared to re
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/venue-setup.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/venue-setup.pdf}) - translated by António Gomes

--- a/edudoc/organizer-guidelines/work-during-comp.md
+++ b/edudoc/organizer-guidelines/work-during-comp.md
@@ -52,4 +52,4 @@ As the previous group is finishing up, you should start preparing for the next o
 
 Below you can find translations of this document. Contact quality@worldcubeassociation.org for instructions on how to add your own translation.
 
-- [Português Europeu (European Portuguese)](https://worldcubeassociation.org/edudoc/organizer-guidelines/pt/work-during-comp.pdf) - translated by António Gomes
+- [Português Europeu (European Portuguese)](wcadoc{edudoc/organizer-guidelines/pt/work-during-comp.pdf}) - translated by António Gomes


### PR DESCRIPTION
Fixed:
- A lot of links with `https://worldcubeassociation.org/...` (missing subdomain). Those were replaced with wcadoc{...}.
- A lot of link in the Delegate Crash Course with the old subdomain (www). Also replaced with wcadoc{...}.
- Build script. @thewca/software-team Please check the fix, I'm not sure if the www was missing or if it was on purpose.