### PR TITLE
Update logo usage policy

### DIFF
--- a/documents/policies/external/Logo Usage.md
+++ b/documents/policies/external/Logo Usage.md
@@ -14,6 +14,10 @@ The logo covered by this policy is the [logo registered with the US Patent and T
 
 The registered symbol (®) must be included in all contexts and jurisdictions where the logo is used.
 
+### WCA Staff
+
+Members of WCA Staff may use the WCA logo on internal documents, presentations, and other materials related to their work for the WCA.
+
 ### WCA Competitions
 
 Organizers and/or Delegates may use the logo on the website, printings, and apparel of competitions that have been approved by the World Cube Association.

--- a/documents/policies/external/Logo Usage.md
+++ b/documents/policies/external/Logo Usage.md
@@ -1,35 +1,57 @@
 # WCA Logo Usage Policy
 
-### Version 1.0 {.version}
+### Version 2.0 {.version}
 
 ## Purpose
-The WCA logo was designed for the World Cube Association by Justin Eastman in a design contest in January 2005. A 3D version of the logo was designed by Vu Minh Tan. This policy outlines the allowed usage of the WCA logo.
+
+The WCA logo was designed for the World Cube Association by Justin Eastman in a design contest in January 2005. This policy outlines the allowed usage of the WCA logo. Downloadable versions of the WCA logo can be found on the [logo page](https://www.worldcubeassociation.org/logo) of the WCA website.
 
 ## Policy
-### Logo Versions
-The following versions of the logo are covered by this policy:
 
-- [Large version](wca{files/WCAlogo_XL.jpg})
-- [Vector version](wca{files/WCAlogo.svg})
-- [Vector version without text](wca{files/WCAlogo_notext.svg})
-- [3D version](wca{files/WCALogo3D.png})
+### Logo Versions
+
+The logo covered by this policy is the [logo registered with the US Patent and Trademark Office](https://tsdr.uspto.gov/#caseNumber=88465009&caseSearchType=US_APPLICATION&caseType=DEFAULT&searchType=statusSearch), serial number 88465009.
+
+The registered symbol (®) must be included in all contexts and jurisdictions where the logo is used.
 
 ### WCA Competitions
+
 Organizers and/or Delegates may use the logo on the website, printings, and apparel of competitions that have been approved by the World Cube Association.
 
 ### Regional Organizations
+
 Regional Organizations that are [officially recognized](wca{organizations}) by the World Cube Association may use the WCA logo on their website, printings, and apparel.
 
 ### Merchandising
+
 #### Merchandise for WCA competitions
+
 1. Organizers and/or Delegates of WCA competitions may use the WCA logo on gifts, banners, or decorations without any charge.
 2. Organizers and/or Delegates of WCA competitions may use the WCA logo on merchandise to be sold at competitions. However, ten percent (10%) of gross sales shall be transferred to the WCA via the WCA Financial Committee.
 
 #### Merchandise sold by Third Parties
-Any requests to use the WCA logo on merchandise that will be sold must be negotiated with and approved by the WCA Board of Directors. Please email the [WCA Board](mailto:board@worldcubeassociation.org) to request such an arrangement.
 
-### Usage on a Personal Website
-The WCA logo may not​ be used on any personal websites.
+Any requests to use the WCA logo on merchandise that will be sold must be negotiated with and approved by the WCA Marketing Team. Please email the [WCA Marketing Team](mailto:marketing@worldcubeassociation.org) to request such an arrangement.
 
-### Other {.page-break-before}
-All other requests to use the WCA logo for purposes not already outlined in this policy must be approved on a case by case basis by the WCA Board of Directors.
+## Usage on a Personal Website
+
+### Permitted Use
+
+- Use the WCA logo for an official WCA competition within the limits of being in direct relationship to the competition
+- Use the WCA logo to link to official WCA affiliated resources such as the WCA website, WCA Live, and the WCA Forum
+- Use the WCA logo as a button to link to a WCA profile
+- Use the WCA logo to indicate that a project integrates with the WCA, such as using the WCA’s OAuth login
+- Use the WCA logo in a blog post or news article about the WCA
+- Use the WCA logo less prominently than the logo for an associated product
+
+### Prohibited Use
+
+- Do not use the WCA logo to implicitly or explicitly suggest official representation or endorsement by the WCA of any product or service
+- Do not use the WCA logo as the icon or logo of another business, organization, product, service, project, social media account, or website
+- Do not modify the permitted WCA logos by changing the dimensions, colors, words, or other design elements
+- Do not use the WCA logo without the registered symbol (®)
+- Do not use the WCA logo for any other reason not mentioned in this document without the WCA Marketing Team’s prior written permission
+
+## Other
+
+All other requests to use the WCA logo for purposes not already outlined in this policy must be approved on a case-by-case basis by the WCA. Please reach out to the [WCA Marketing Team](mailto:marketing@worldcubeassociation.org) for more information.


### PR DESCRIPTION
Updating the logo usage policy per discussion had via email w/ Board, plus additional changes regarding registered symbol.

Changes to the policy are broadly:
    
- Modify logos covered by the policy to those registered with USPTO
- Require the use of the Registered symbol
- Transfer logo usage approvals from the Board to WMT
- Create guidelines for the usage of the logo on personal websites