### PR TITLE
Update Guidelines for Disc. Inc. to refer to WIC

### DIFF
--- a/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.md
+++ b/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.md
@@ -4,7 +4,7 @@ The WCA Integrity Committee (WIC) is entitled to apply bans and other disciplina
 
 ## Disciplinary Log and Banned Competitors
 
-- A list of banned competitors can be found in the [Disciplinary log](wca{disciplinary}). If a competitor attempts to attend a competition when they are banned from doing so, please contact the WIC.
+- A list of banned competitors can be found in the [Delegate panel](wca{panel/delegate#banned-competitors}). If a competitor attempts to attend a competition when they are banned from doing so, please contact the WIC.
 - Depending on the degree of severity and type of violation of the Code of Conduct, the WIC may ban a competitor from competing or attending competitions. Such a ban will be communicated with local Delegates when it is issued. If a competitor is banned from competing, but not from attending competitions, they are permitted to attend competitions. They may also fulfill the roles of officials at competitions at the discretion of the WCA Delegate.
 - The WIC will publish reports on remarkable cases they've managed and issue a quarterly digest showcasing smaller resolved cases from the previous quarter. These publications aim to educate the community and WCA staff, promoting transparency. You can find them in the announcement section on the WCA homepage and forum, with a comprehensive list available in the [Disciplinary log](wca{disciplinary}).
 
@@ -24,7 +24,7 @@ The WCA Integrity Committee (WIC) is entitled to apply bans and other disciplina
 
 ## Theft at Competitions
 
-- The WIC’s preference is for theft (such as stealing puzzles) to be investigated and resolved locally when possible, as the local Delegates can often resolve these cases better than the WIC. The priority for these cases is getting items returned to owners during the competition. The WIC will generally not apply disciplinary action unless a competitor has been caught stealing after a previous warning or all of the following conditions are met:
+- The WIC's preference is for theft (such as stealing puzzles) to be investigated and resolved locally when possible, as the local Delegates can often resolve these cases better than the WIC. The priority for these cases is getting items returned to owners during the competition. The WIC will generally not apply disciplinary action unless a competitor has been caught stealing after a previous warning or all of the following conditions are met:
   - There is definitive proof of the accused person committing theft (such as a witness seeing them steal, CCTV footage, admission of guilt, etc.).
   - The suspect has been contacted and asked to return missing items.
   - The suspect has been unresponsive/uncooperative and has not returned missing items.
@@ -48,7 +48,7 @@ The Code of Conduct is limited in scope to WCA Competitions and online on offici
 
 - If competitors/parents/others are being impolite or inappropriate in their online interactions related to competitions, then please do your best to respectfully handle the situation (please keep in mind that you are a representative of the WCA). You may reach out to the WIC for advice on how to best handle the situation if the problem persists or you are unsure of how to proceed.
 - If you feel a person may engage in disruptive actions or pose a threat to the safety or well-being or anyone during a WCA-sanctioned competition based on their online behavior, then please contact the WIC.
-- For any incidents on the WCA forum or other official WCA platforms please contact the moderators, such as the WAC on the WCA forums. The WIC would like for minor behavioral incidents to be handled “locally” online on official WCA platforms– such as through the means of warnings, mutes, or bans–before the WIC is contacted to request disciplinary action being enacted. Please only contact the WIC for serious incidents that take place online on official WCA platforms.
+- For any incidents on the WCA forum or other official WCA platforms please contact the WCA Communications Team (WCT). The WIC would like for minor behavioral incidents to be handled "locally" online on official WCA platforms– such as through the means of warnings, mutes, or bans–before the WIC is contacted to request disciplinary action being enacted. Please only contact the WIC for serious incidents that take place online on official WCA platforms.
 
 ## Organizers
 
@@ -82,10 +82,10 @@ The Code of Conduct is limited in scope to WCA Competitions and online on offici
 
 Competitions can be demanding, difficult situations that can add another level of stress. It is essential to remain professional at all times; this will help your interactions with others to go more smoothly, and allow you to positively represent the WCA. Keep in mind the following points when managing a difficult situation:
 
-- Remain calm during your interactions, speak slowly, avoid arguing, avoid shouting, don’t use overly complicated jargon, and try to be understanding of others. Doing this will allow you to handle the situation in a calm manner and avoid conflict.
+- Remain calm during your interactions, speak slowly, avoid arguing, avoid shouting, don't use overly complicated jargon, and try to be understanding of others. Doing this will allow you to handle the situation in a calm manner and avoid conflict.
 - If you are imposing an unpopular ruling, explain clearly why you are doing it. If the competitor is young, it may be beneficial to involve their parent/guardian. Some competitors are easily embarrassed. One way to defuse that tension is to draw from personal experience, and let them know that the same situation has happened to you before.
-  - Example: a young competitor doesn’t start their timer correctly and becomes upset as their attempt has been given a DNF penalty. Speak to their parents, use more straightforward terms such as “disqualify” rather than DNF, to explain what happened. Show the competitor how to start the timer correctly. Tell them about a time it happened to you, maybe a time when you had a particularly good scramble. Give them tips on how you have avoided this happening again.
+  - Example: a young competitor doesn't start their timer correctly and becomes upset as their attempt has been given a DNF penalty. Speak to their parents, use more straightforward terms such as "disqualify" rather than DNF, to explain what happened. Show the competitor how to start the timer correctly. Tell them about a time it happened to you, maybe a time when you had a particularly good scramble. Give them tips on how you have avoided this happening again.
 - If you are becoming frustrated during an interaction, ask for help early or get another Delegate/organizer/trusted person to step in. If this is not possible consider taking a break from the situation and rediscussing the matter with the people involved at a later point in the competition.
 - When there are multiple difficult situations occurring at competitions, try and prioritize what is the most important and where possible assign others (either Delegates, organizers or other trusted individuals) to deal with the less important or less time-critical issues.
-- After you have managed a difficult situation, it is important to debrief. Speak with the other Delegates/organizers/trusted people involved; discuss what went well, what could’ve been improved, what you learned, and avoid blaming others if things went poorly. If you were the only person involved, reach out to a Delegate you trust and debrief.
+- After you have managed a difficult situation, it is important to debrief. Speak with the other Delegates/organizers/trusted people involved; discuss what went well, what could've been improved, what you learned, and avoid blaming others if things went poorly. If you were the only person involved, reach out to a Delegate you trust and debrief.
 - Use the Delegate report as a resource to gather feedback on how you managed the situation, and how you could have managed the situation differently. This also acts as a resource for others to learn how they may be able to manage similar situations.

--- a/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.md
+++ b/edudoc/guidelines-for-disciplinary-incidents/guidelines-for-disciplinary-incidents.md
@@ -1,93 +1,91 @@
 # Guidelines for Disciplinary Incidents
 
-The WCA Disciplinary Committee (WDC) is entitled to apply bans and other disciplinary action as a result of violation of the [WCA Code of Conduct](wcadoc{documents/Code%20of%20Conduct.pdf}), based on the motion [Suspensions and other Sanctions](wcadoc{documents/motions/15.2022.1%20-%20Suspensions%20and%20other%20Sanctions.pdf}). However, the Committee is not able to handle difficult situations quickly during a competition, especially if communication with multiple involved parties is required. Cooperation with competition Delegates is often necessary. This document contains a collection of guidelines to instruct new Delegates on how to handle common disciplinary incidents, what disciplinary measures they can take, and what they should report to the WDC.
+The WCA Integrity Committee (WIC) is entitled to apply bans and other disciplinary action as a result of violation of the [WCA Code of Conduct](wcadoc{documents/Code%20of%20Conduct.pdf}), based on the motion [Suspensions and other Sanctions](wcadoc{documents/motions/15.2022.1%20-%20Suspensions%20and%20other%20Sanctions.pdf}). However, the WIC is not able to handle difficult situations quickly during a competition, especially if communication with multiple involved parties is required. Cooperation with competition Delegates is often necessary. This document contains a collection of guidelines to instruct new Delegates on how to handle common disciplinary incidents, what disciplinary measures they can take, and what they should report to the WIC.
 
 ## Disciplinary Log and Banned Competitors
 
-* A list of banned competitors can be found in the [Disciplinary log](wca{disciplinary}). If a competitor attempts to attend a competition when they are banned from doing so, please contact the WDC.
-* Depending on the degree of severity and type of violation of the Code of Conduct, the WDC may ban a competitor from competing or attending competitions. Such a ban will be communicated with local Delegates when it is issued. If a competitor is banned from competing, but not from attending competitions, they are permitted to attend competitions. They may also fulfill the roles of officials at competitions at the discretion of the WCA Delegate.
-* The WDC will publish reports on remarkable cases they've managed and issue a quarterly digest showcasing smaller resolved cases from the previous quarter. These publications aim to educate the community and WCA staff, promoting transparency. You can find them in the announcement section on the WCA homepage and forum, with a comprehensive list available in the [Disciplinary log](wca{disciplinary}).
+- A list of banned competitors can be found in the [Disciplinary log](wca{disciplinary}). If a competitor attempts to attend a competition when they are banned from doing so, please contact the WIC.
+- Depending on the degree of severity and type of violation of the Code of Conduct, the WIC may ban a competitor from competing or attending competitions. Such a ban will be communicated with local Delegates when it is issued. If a competitor is banned from competing, but not from attending competitions, they are permitted to attend competitions. They may also fulfill the roles of officials at competitions at the discretion of the WCA Delegate.
+- The WIC will publish reports on remarkable cases they've managed and issue a quarterly digest showcasing smaller resolved cases from the previous quarter. These publications aim to educate the community and WCA staff, promoting transparency. You can find them in the announcement section on the WCA homepage and forum, with a comprehensive list available in the [Disciplinary log](wca{disciplinary}).
 
-## Handling Behavioral Issues of Competitors at Competitions 
+## Handling Behavioral Issues of Competitors at Competitions
 
-* Delegates should primarily address minor behavioral issues of competitors at competitions themselves using [2j](wca{regulations/#2j}), [2k](wca{regulations/#2k}), and [2l](wca{regulations/#2l}) of the regulations and applicable sub-points.
-  * If Delegates have not first tried to handle minor behavior issues by giving warnings and disqualifying competitors under regulation 2k, then the WDC is much less likely to apply any disciplinary action. We would like Delegates to attempt to handle minor incidents at a local level first before WDC gets involved. However, the WDC would like Delegates to report noteworthy behavioral issues so the WDC can record them. The WDC is always willing to give advice and take disciplinary action as needed.
-* If any extraordinary cases occur, please describe them in the Delegate Report.
-  * Please be aware the WDC will likely contact you for further information regarding the case.
-  * If an incident is discovered after the competition, this should be added to the Delegate Report, or emailed to the Delegate Report thread.
-  * If the case contains information of a sensitive or private nature, it is acceptable to exclude these details from the Delegate Report. However, it is important that the WDC is contacted directly with these details.
-* Please contact the WDC (tagging in the Delegate Report or directly):
-  * If the conflict cannot be resolved locally.
-  * If you believe that a person should be officially warned by the WDC or banned from competitions.
-  * If you believe that similar incidents may occur in the future and that it would be beneficial for the WDC to document the incident.
-* For extreme situations where competitor safety may be involved, please contact local law enforcement immediately. Once the immediate concerns of safety have been addressed, contact the WDC with all evidence gathered for the WDC to use in their investigation.
+- Delegates should primarily address minor behavioral issues of competitors at competitions themselves using [2j](wca{regulations/#2j}), [2k](wca{regulations/#2k}), and [2l](wca{regulations/#2l}) of the regulations and applicable sub-points.
+  - If Delegates have not first tried to handle minor behavior issues by giving warnings and disqualifying competitors under regulation 2k, then the WIC is much less likely to apply any disciplinary action. We would like Delegates to attempt to handle minor incidents at a local level first before WIC gets involved. However, the WIC would like Delegates to report noteworthy behavioral issues so the WIC can record them. The WIC is always willing to give advice and take disciplinary action as needed.
+- If any extraordinary cases occur, please describe them in the Delegate Report.
+  - Please be aware the WIC will likely contact you for further information regarding the case.
+  - If an incident is discovered after the competition, this should be added to the Delegate Report, or emailed to the Delegate Report thread.
+  - If the case contains information of a sensitive or private nature, it is acceptable to exclude these details from the Delegate Report. However, it is important that the WIC is contacted directly with these details.
+- Please contact the WIC (tagging in the Delegate Report or directly):
+  - If the conflict cannot be resolved locally.
+  - If you believe that a person should be officially warned by the WIC or banned from competitions.
+  - If you believe that similar incidents may occur in the future and that it would be beneficial for the WIC to document the incident.
+- For extreme situations where competitor safety may be involved, please contact local law enforcement immediately. Once the immediate concerns of safety have been addressed, contact the WIC with all evidence gathered for the WIC to use in their investigation.
 
 ## Theft at Competitions
 
-* The WDC’s preference is for theft (such as stealing puzzles) to be investigated and resolved locally when possible, as the local Delegates can often resolve these cases better than the WDC. The priority for these cases is getting items returned to owners during the competition. The WDC will generally not apply disciplinary action unless a competitor has been caught stealing after a previous warning or all of the following conditions are met:
-  * There is definitive proof of the accused person committing theft (such as a witness seeing them steal, CCTV footage, admission of guilt, etc.).
-  * The suspect has been contacted and asked to return missing items.
-  * The suspect has been unresponsive/uncooperative and has not returned missing items.
-* If you receive reports that lead you to believe that there has been theft, then do your best to resolve the situation during the competition if possible.
-  * Make an announcement, giving a description of missing items and advising competitors to give items to an organizer or Delegate if they are found. In past incidents, competitors have returned missing items after similar announcements.
-  * Ask competitors if they witnessed anything that could be related to the theft (e.g. someone standing next to a table where puzzles went missing or seeing someone playing with a puzzle that went missing).
-  * Talk to any suspects and ask direct questions. If they confess and return any missing items, thank them for their honesty and warn them to avoid stealing in the future if they deliberately took the item. Keep the age and maturity of the individual in mind.
-  * Ask the venue for security camera footage to identify potential suspects if possible.
-* If puzzles were not returned at the competition, but you believe you know who may have stolen them then contact them and ask for the puzzles to be returned. Contact the WDC if the individual is not responsive or is unwilling to return the puzzles.
-* Report incidents of theft to the WDC so that we can note down competitors names in case there are repeated cases of theft in the future.
+- The WIC’s preference is for theft (such as stealing puzzles) to be investigated and resolved locally when possible, as the local Delegates can often resolve these cases better than the WIC. The priority for these cases is getting items returned to owners during the competition. The WIC will generally not apply disciplinary action unless a competitor has been caught stealing after a previous warning or all of the following conditions are met:
+  - There is definitive proof of the accused person committing theft (such as a witness seeing them steal, CCTV footage, admission of guilt, etc.).
+  - The suspect has been contacted and asked to return missing items.
+  - The suspect has been unresponsive/uncooperative and has not returned missing items.
+- If you receive reports that lead you to believe that there has been theft, then do your best to resolve the situation during the competition if possible.
+  - Make an announcement, giving a description of missing items and advising competitors to give items to an organizer or Delegate if they are found. In past incidents, competitors have returned missing items after similar announcements.
+  - Ask competitors if they witnessed anything that could be related to the theft (e.g. someone standing next to a table where puzzles went missing or seeing someone playing with a puzzle that went missing).
+  - Talk to any suspects and ask direct questions. If they confess and return any missing items, thank them for their honesty and warn them to avoid stealing in the future if they deliberately took the item. Keep the age and maturity of the individual in mind.
+  - Ask the venue for security camera footage to identify potential suspects if possible.
+- If puzzles were not returned at the competition, but you believe you know who may have stolen them then contact them and ask for the puzzles to be returned. Contact the WIC if the individual is not responsive or is unwilling to return the puzzles.
+- Report incidents of theft to the WIC so that we can note down competitors names in case there are repeated cases of theft in the future.
 
 ## Handling Behavioral Issues of Spectators at Competitions {.page-break-before}
 
-* Local Delegates should do their best to handle any issues that arise with spectators in a respectful manner, remembering that they are acting as official representatives of the WCA.
-* Be aware of venue rules and policies. You may be able to ask an official from the venue or local law enforcement to remove individuals causing problems if needed. 
-* Contact local law enforcement immediately if there is extreme behavior that may threaten competitor safety. Once the immediate concerns of safety have been addressed, contact the WDC to report the details of what happened.
+- Local Delegates should do their best to handle any issues that arise with spectators in a respectful manner, remembering that they are acting as official representatives of the WCA.
+- Be aware of venue rules and policies. You may be able to ask an official from the venue or local law enforcement to remove individuals causing problems if needed.
+- Contact local law enforcement immediately if there is extreme behavior that may threaten competitor safety. Once the immediate concerns of safety have been addressed, contact the WIC to report the details of what happened.
 
 ## Online Interactions (WCA Forum/Official WCA Platforms)
-The Code of Conduct is limited in scope to WCA Competitions and online on official WCA platforms. As a result, the WDC cannot take any action in response to online incidents that happen outside of official WCA platforms.
 
-* If competitors/parents/others are being impolite or inappropriate in their online interactions related to competitions, then please do your best to respectfully handle the situation (please keep in mind that you are a representative of the WCA). You may reach out to the WDC for advice on how to best handle the situation if the problem persists or you are unsure of how to proceed.
-* If you feel a person may engage in disruptive actions or pose a threat to the safety or well-being or anyone during a WCA-sanctioned competition based on their online behavior, then please contact the WDC.
-* For any incidents on the WCA forum or other official WCA platforms please contact the moderators, such as the WAC on the WCA forums. The WDC would like for minor behavioral incidents to be handled “locally” online on official WCA platforms– such as through the means of warnings, mutes, or bans–before the WDC is contacted to request disciplinary action being enacted. Please only contact the WDC for serious incidents that take place online on official WCA platforms.
+The Code of Conduct is limited in scope to WCA Competitions and online on official WCA platforms. As a result, the WIC cannot take any action in response to online incidents that happen outside of official WCA platforms.
+
+- If competitors/parents/others are being impolite or inappropriate in their online interactions related to competitions, then please do your best to respectfully handle the situation (please keep in mind that you are a representative of the WCA). You may reach out to the WIC for advice on how to best handle the situation if the problem persists or you are unsure of how to proceed.
+- If you feel a person may engage in disruptive actions or pose a threat to the safety or well-being or anyone during a WCA-sanctioned competition based on their online behavior, then please contact the WIC.
+- For any incidents on the WCA forum or other official WCA platforms please contact the moderators, such as the WAC on the WCA forums. The WIC would like for minor behavioral incidents to be handled “locally” online on official WCA platforms– such as through the means of warnings, mutes, or bans–before the WIC is contacted to request disciplinary action being enacted. Please only contact the WIC for serious incidents that take place online on official WCA platforms.
 
 ## Organizers
 
-* Like any other competitors, report any violations of the Code of Conduct to the WDC.
-* If an organizer has done something outside of the scope of the Code of Conduct that you feel could be problematic, then it is up to discretion of the Delegate to work with that organizer or not. For example, if an organizer has made racist comments on a non-WCA online forum, then the Delegate can choose to not work with that organizer. 
-* Carefully keep track of competition budgets and actual expenditures that take place, documenting expenditures with receipts when possible. If you believe that an organizer or legal entity is retaining leftover money from competitions for personal gain then please contact the WDC.
+- Like any other competitors, report any violations of the Code of Conduct to the WIC.
+- If an organizer has done something outside of the scope of the Code of Conduct that you feel could be problematic, then it is up to discretion of the Delegate to work with that organizer or not. For example, if an organizer has made racist comments on a non-WCA online forum, then the Delegate can choose to not work with that organizer.
+- Carefully keep track of competition budgets and actual expenditures that take place, documenting expenditures with receipts when possible. If you believe that an organizer or legal entity is retaining leftover money from competitions for personal gain then please contact the WIC.
 
 ## WCA Staff Members {.page-break-before}
 
-* Like any other competitors, report any violations of the Code of Conduct of WCA Staff to the WDC. Be sure to also use ‘CC’ to include the WCA Ethics Committee (WEC) in your email.
-* If you need to report a violation of the Code of Conduct or Code of Ethics of a Staff member who is a member of the WDC or the WEC, then please report this behavior in one of the following ways:
-  * Contact the Leader and/or Senior members of the Committee usually responsible for handling the infraction.
-    * E.g. If a WDC member has violated the Code of Conduct, then contact the WDC leader and/or senior members of the WDC.
-  * Contact the WDC if a WEC member has committed a violation of the Code of Ethics.
-  * Contact the WEC if a WDC member has committed a violation of the Code of Conduct.
+- Like any other competitors, report any violations of the Code of Conduct of WCA Staff to the WIC.
+- If you need to report a violation of the Code of Conduct or Code of Ethics of a Staff member who is a member of the WIC, then please report this behavior to the WCA Appeals Committee at [appeals@worldcubeassociation.org](mailto:appeals@worldcubeassociation.org).
 
 ## Cheating
 
-* If cheating is obvious, try to get evidence (especially videos, photos, names of people involved, and email addresses of witnesses) and disqualify the competitor using Regulation [2k2](wca{regulations/#2k2}). At your discretion, you may let the suspect complete the attempt or the round before disqualifying them, in order to gather more evidence.
-  * For example, if a competitor is reported to have peeked on their first attempt of 3x3 blindfolded, it may be desirable to watch them/record them peeking on their 2nd and 3rd attempts before disqualification, as opposed to immediately disqualifying the competitor. This allows the WDC to have greater evidence, which is necessary for taking disciplinary action.
-  * Explain to competitors why their actions were wrong, try to explain the importance of fairness, and ask them if they have cheated in similar ways in the past. Explain to them that their actions will be reported to the WDC and that the WDC may contact them. Also explain that if a WDC investigation is started, that honesty will result in the best outcome for the competitor.
-* Tag the WDC in the Delegate report about the case. Give a rough outline of the incident for the education of other Delegates, but avoid including any evidence or identifying information in the report such as videos that reveal the identity of competitors or names of competitors accused of cheating.
-* Contact the WDC directly with a detailed description of the incident, and any evidence gathered.
+- If cheating is obvious, try to get evidence (especially videos, photos, names of people involved, and email addresses of witnesses) and disqualify the competitor using Regulation [2k2](wca{regulations/#2k2}). At your discretion, you may let the suspect complete the attempt or the round before disqualifying them, in order to gather more evidence.
+  - For example, if a competitor is reported to have peeked on their first attempt of 3x3 blindfolded, it may be desirable to watch them/record them peeking on their 2nd and 3rd attempts before disqualification, as opposed to immediately disqualifying the competitor. This allows the WIC to have greater evidence, which is necessary for taking disciplinary action.
+  - Explain to competitors why their actions were wrong, try to explain the importance of fairness, and ask them if they have cheated in similar ways in the past. Explain to them that their actions will be reported to the WIC and that the WIC may contact them. Also explain that if a WIC investigation is started, that honesty will result in the best outcome for the competitor.
+- Tag the WIC in the Delegate report about the case. Give a rough outline of the incident for the education of other Delegates, but avoid including any evidence or identifying information in the report such as videos that reveal the identity of competitors or names of competitors accused of cheating.
+- Contact the WIC directly with a detailed description of the incident, and any evidence gathered.
 
 ## Incidents Outside the Scope of the Code of Conduct
-The Code of Conduct is limited in scope to WCA Competitions and online on official WCA platforms. As a result, the WDC cannot take any action in response to incidents that happen outside of this scope. If concerning behavior happens outside of this scope, below are some recommendations.
 
-* Contact authority figures that may be able to resolve the situation, such as parents, school administrators, or moderators of a social media group.
-* If the situation is serious enough (e.g. physical threats, bullying, abusive behavior, sexual harassment) then contact local law enforcement.
-* If you feel it is necessary, communicate with the individual about their behavior and contact the WDC, keeping in mind that the WDC may not be able to apply sanctions. In your communications make it clear that you are contacting them as a concerned individual and not a representative of the WCA. For example, do not threaten disciplinary action from the WCA, such as removal from competitions.
-  * If harassment/bullying is occurring online, advise the victim to block the perpetrator(s).
+The Code of Conduct is limited in scope to WCA Competitions and online on official WCA platforms. As a result, the WIC cannot take any action in response to incidents that happen outside of this scope. If concerning behavior happens outside of this scope, below are some recommendations.
+
+- Contact authority figures that may be able to resolve the situation, such as parents, school administrators, or moderators of a social media group.
+- If the situation is serious enough (e.g. physical threats, bullying, abusive behavior, sexual harassment) then contact local law enforcement.
+- If you feel it is necessary, communicate with the individual about their behavior and contact the WIC, keeping in mind that the WIC may not be able to apply sanctions. In your communications make it clear that you are contacting them as a concerned individual and not a representative of the WCA. For example, do not threaten disciplinary action from the WCA, such as removal from competitions.
+  - If harassment/bullying is occurring online, advise the victim to block the perpetrator(s).
 
 ## Managing Difficult Situations {.page-break-before}
 
 Competitions can be demanding, difficult situations that can add another level of stress. It is essential to remain professional at all times; this will help your interactions with others to go more smoothly, and allow you to positively represent the WCA. Keep in mind the following points when managing a difficult situation:
 
-* Remain calm during your interactions, speak slowly, avoid arguing, avoid shouting, don’t use overly complicated jargon, and try to be understanding of others. Doing this will allow you to handle the situation in a calm manner and avoid conflict.
-* If you are imposing an unpopular ruling, explain clearly why you are doing it. If the competitor is young, it may be beneficial to involve their parent/guardian. Some competitors are easily embarrassed. One way to defuse that tension is to draw from personal experience, and let them know that the same situation has happened to you before.
-  * Example: a young competitor doesn’t start their timer correctly and becomes upset as their attempt has been given a DNF penalty. Speak to their parents, use more straightforward terms such as “disqualify” rather than DNF, to explain what happened. Show the competitor how to start the timer correctly. Tell them about a time it happened to you, maybe a time when you had a particularly good scramble. Give them tips on how you have avoided this happening again.
-* If you are becoming frustrated during an interaction, ask for help early or get another Delegate/organizer/trusted person to step in. If this is not possible consider taking a break from the situation and rediscussing the matter with the people involved at a later point in the competition.
-* When there are multiple difficult situations occurring at competitions, try and prioritize what is the most important and where possible assign others (either Delegates, organizers or other trusted individuals) to deal with the less important or less time-critical issues.
-* After you have managed a difficult situation, it is important to debrief. Speak with the other Delegates/organizers/trusted people involved; discuss what went well, what could’ve been improved, what you learned, and avoid blaming others if things went poorly. If you were the only person involved, reach out to a Delegate you trust and debrief.
-* Use the Delegate report as a resource to gather feedback on how you managed the situation, and how you could have managed the situation differently. This also acts as a resource for others to learn how they may be able to manage similar situations.
+- Remain calm during your interactions, speak slowly, avoid arguing, avoid shouting, don’t use overly complicated jargon, and try to be understanding of others. Doing this will allow you to handle the situation in a calm manner and avoid conflict.
+- If you are imposing an unpopular ruling, explain clearly why you are doing it. If the competitor is young, it may be beneficial to involve their parent/guardian. Some competitors are easily embarrassed. One way to defuse that tension is to draw from personal experience, and let them know that the same situation has happened to you before.
+  - Example: a young competitor doesn’t start their timer correctly and becomes upset as their attempt has been given a DNF penalty. Speak to their parents, use more straightforward terms such as “disqualify” rather than DNF, to explain what happened. Show the competitor how to start the timer correctly. Tell them about a time it happened to you, maybe a time when you had a particularly good scramble. Give them tips on how you have avoided this happening again.
+- If you are becoming frustrated during an interaction, ask for help early or get another Delegate/organizer/trusted person to step in. If this is not possible consider taking a break from the situation and rediscussing the matter with the people involved at a later point in the competition.
+- When there are multiple difficult situations occurring at competitions, try and prioritize what is the most important and where possible assign others (either Delegates, organizers or other trusted individuals) to deal with the less important or less time-critical issues.
+- After you have managed a difficult situation, it is important to debrief. Speak with the other Delegates/organizers/trusted people involved; discuss what went well, what could’ve been improved, what you learned, and avoid blaming others if things went poorly. If you were the only person involved, reach out to a Delegate you trust and debrief.
+- Use the Delegate report as a resource to gather feedback on how you managed the situation, and how you could have managed the situation differently. This also acts as a resource for others to learn how they may be able to manage similar situations.


### PR DESCRIPTION
Replace references of WDC to WIC. Small adjustments around reports of WIC members to WAC since the process is slightly different than it was with WEC/WDC.