### PR TITLE
Remove WEC from CoE CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 * @thewca/software-team
 documents/ @thewca/board
-documents/Code\ of\ Ethics.md @thewca/wec
 edudoc/ @thewca/wqac
 editable-image-files/ @thewca/wqac


### PR DESCRIPTION
Modifications to the CoE cannot be merged without Board approval. This removes WEC from the CODEOWNERS to more clearly communicate that Board approval is required before merging.

Also WEC no longer exists anyway.