### PR TITLE
Update Competition Requirements.md

### DIFF
--- a/documents/policies/external/Competition Requirements.md
+++ b/documents/policies/external/Competition Requirements.md
@@ -1,6 +1,6 @@
 # WCA Competition Requirements Policy
 
-### Version 5.1 {.version}
+### Version 5.2 {.version}
 
 ## Purpose
 The purpose of this policy is to define the requirements and processes that a competition must meet and follow in order to be recognized as a WCA Competition.
@@ -66,7 +66,7 @@ The WCA Delegate must submit the following information when requesting approval 
    2. Capitalization of the competition name must be appropriate. The first letter of each word in the competition’s name must be capitalized and subsequent letters within words should be lowercase, except articles and prepositions, which should be always lowercase. Acronyms should be capitalized.
       1. Exception: The first letter of a word may be left lowercase if it is formatted as such in the name of a company or venue.
       2. Each word in the name should be separated by a space unless CamelCasing is appropriate.
-   3. The name must end with the year of the last day of the competition.
+   3. The name must end with the year of the first day of the competition.
    4. The competition name must be in Roman-readable letters and may only contain characters from A-Z, a-z, 0-9, or similar characters.
       1. Only the following special characters are permitted: Apostrophe (‘), period (.), colon (:), hyphen (-), and ampersand (&).
       2. Numbers may not be used in place of a word.


### PR DESCRIPTION
After discussions between WCAT and WRT we have decided to update the policy on the how the years in competition names and IDs are handled. They will now be based on the first day of the competition. This will resolve a discrepancy between how years are handled between WCA IDs and competition IDs.