### PR TITLE
Fix pagetitle for minutes and motions

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -21,8 +21,14 @@ convert_to_pdf() {
     pdf_path="${file%.md}.pdf"
     html_path="${file%.md}.html"
 
-    # Use first header as the document title; remove all # characters and whitespace from the beginning
-    document_title=$(head -n 1 "$file" | sed -E "s/^#+\s*//")
+    if [[ "$file" =~ build/documents/(motions|minutes)/(([a-zA-Z0-9.\-]|[[:blank:]])+)\.md ]]; then
+      # We need this for minutes and motions to have the correct document title. Otherwise it uses "{.text-center}"
+      # or "SUBMISSION OF PROPOSED MOTION".
+      document_title=${BASH_REMATCH[2]}
+    else
+      # Use first header as the document title; remove all # characters and whitespace from the beginning
+      document_title=$(head -n 1 "$file" | sed -E "s/^#+\s*//")
+    fi
     # Absolute path to the custom stylesheet
     custom_stylesheet="./assets/$1-style.css"
     custom_stylesheet_path=$(realpath "$custom_stylesheet")

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -21,7 +21,7 @@ convert_to_pdf() {
     pdf_path="${file%.md}.pdf"
     html_path="${file%.md}.html"
 
-    if [[ "$file" =~ build/documents/(motions|minutes)/(([a-zA-Z0-9.\-]|[[:blank:]])+)\.md ]]; then
+    if [[ "$file" =~ build/documents/(motions|minutes)/(([a-zA-Z0-9._\-]|[[:blank:]])+)\.md ]]; then
       # We need this for minutes and motions to have the correct document title. Otherwise it uses "{.text-center}"
       # or "SUBMISSION OF PROPOSED MOTION".
       document_title=${BASH_REMATCH[2]}


### PR DESCRIPTION
Fixes https://github.com/thewca/wca-documents/issues/398

I'm not a bash expert, but I think this solution should be fine.

Note that I used `(([a-zA-Z0-9.\-]|[[:blank:]])+)\.md` to match the filename. I tried `[a-zA-Z0-9.\- ]`, `[a-zA-Z0-9.\-\ ]` and `[a-zA-Z0-9.\-\s]`, but none of those worked (with docker) to match spaces in the filename. That's why I added `[[:blank:]]`.

Anyway, it can be as simple as `(.+)\.md`, but I guess the complex regex should be safer.