### PR TITLE
Remove WST as wildcard codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
 documents/ @thewca/board
 edudoc/ @thewca/wqac
 editable-image-files/ @thewca/wqac
+bin/ @thewca/software-team
+keys/ @thewca/software-team
+.github/ @thewca/software-team
+.gitignore @thewca/software-team
+Dockerfile @thewca/software-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
+# Actual contents that directly reflect on the documents published on the WCA website
 documents/ @thewca/board
 edudoc/ @thewca/wqac
 editable-image-files/ @thewca/wqac
+
+# Technical configuration, deploy scripts, build environments, etc.
 bin/ @thewca/software-team
 keys/ @thewca/software-team
 .github/ @thewca/software-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
-* @thewca/software-team
 documents/ @thewca/board
 edudoc/ @thewca/wqac
 editable-image-files/ @thewca/wqac

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 documents/ @thewca/board
 edudoc/ @thewca/wqac
 editable-image-files/ @thewca/wqac
+documents-guide @thewca/wqac
 
 # Technical configuration, deploy scripts, build environments, etc.
 bin/ @thewca/software-team


### PR DESCRIPTION
WST probably does not need to be listed as the codeowner (and required therefore) for all files. This commit removes them from CODEOWNERS as a wildcard.

@thewca/software-team if you would like to own specific files or otherwise have comments on this, please let me know.