### PR TITLE
Update upload-artifact to v4

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -2,7 +2,7 @@ name: PR build test
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -17,7 +17,7 @@ jobs:
       - name: Run the PDF compilation process
         run: bin/build.sh
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
`upload-artifact@v2` is full deprecated and causing PR builds to fail. This uploads it to v4 which is the latest version.