### PR TITLE
Fix broken link in WIC motion

### DIFF
--- a/documents/motions/10.2024.3 - Integrity Committee.md
+++ b/documents/motions/10.2024.3 - Integrity Committee.md
@@ -19,7 +19,7 @@ The WCA Integrity Committee is an Advisory Committee of the WCA.
          1. The subjects of the investigations are incidents during WCA Competitions, incidents related to WCA Competitions, incidents related to the function of the Regional Organizations or incidents within the WCA Community. Incidents are alleged violations of the Spirit, Mission, Motions, Policies, Codes and/or Regulations of the WCA.
          2. The investigations can be initiated by the WCA Integrity Committee itself or by the WCA Board.
       3. Delivering an independent report on the investigations.
-      4. Making decisions on disciplinary actions in relation to the investigated incidents. See [WCA Motion : Suspensions and other Sanctions](wcadoc{documents/motions/15.2022.1 - Suspensions and other Sanctions.pdf}).
+      4. Making decisions on disciplinary actions in relation to the investigated incidents. See [WCA Motion : Suspensions and other Sanctions](wcadoc{documents/motions/15.2024.1 - Suspensions and other Sanctions.pdf}).
    2. Confidant
       1. Being the confidential contact for WCA Community members, in case of important disciplinary and ethical matters that are related to WCA activities.
    3. Information and administration


### PR DESCRIPTION
The link to the Suspensions and Sanctions motion was outdated. It will now link to [this one](https://documents.worldcubeassociation.org/documents/motions/15.2024.1%20-%20Suspensions%20and%20other%20Sanctions.pdf).