### PR TITLE
Add WCA Age Policy v1.0

### DIFF
--- a/documents/policies/internal/Age.md
+++ b/documents/policies/internal/Age.md
@@ -1,0 +1,19 @@
+# WCA Age Policy
+
+### Version 1.0 {.version}
+
+## Purpose
+
+The purpose of this policy is to establish age requirements for WCA Volunteers.
+
+## Policy
+
+1. Age is calculated as the number of full years since the date of birth.
+2. Minimum age requirements:
+   1. All WCA Volunteers must be at least 16 years of age.
+   2. Committee and Team Leaders must be at least 18 years of age.
+   3. Trainee Delegates must be at least 17 years of age.
+   4. Junior and Full Delegates must be at least 18 years of age.
+3. WCA Team and Committee Leaders may set an age limit for their team that is strictly higher than the age limit defined in this policy.
+4. This policy does not apply to contractors, competition volunteers, or other individuals who engage in WCA activities but are not WCA Volunteers.
+5. WCA Volunteers who held their roles before this policy took effect may continue in those roles even if they do not meet the age requirements. They cannot take on new roles with age requirements until they meet those requirements.


### PR DESCRIPTION
This PR adds a WCA Age Policy.

It must not be merged until after #450 has been merged, due to the "volunteer" language contained within.