### PR TITLE
Spelling and Grammar Errors in Motions

### DIFF
--- a/documents/motions/05.2025.1 - Election of Directors.md
+++ b/documents/motions/05.2025.1 - Election of Directors.md
@@ -56,7 +56,7 @@ Directors are appointed via an election procedure that is initiated and led by t
       1. If the number of eligible candidates is less than the number of positions (N), all the eligible candidates are declared winners.
          1. After the election the WCA Board shall decide if and when a new election will be started.
       2. If there are more eligible candidates than the number of positions (N) and the voting result of the eligible candidate ranked N+1 equals the voting result of the candidate ranked N, then this produces a tie.
-         1. All eligible candidates with voting result greater than the voting result of the candidate ranked N are declared winners.
+         1. All eligible candidates with a voting result greater than the voting result of the candidate ranked N are declared winners.
          2. For all eligible candidates with the same voting result as the candidate ranked N there will be a tie procedure (see 8.3).
       3. In any other case, the first N ranked eligible candidates are declared winners.
    3. In the event of a tie (as described in 8.2.2.2):

--- a/documents/motions/08.2025.1 - Delegates.md
+++ b/documents/motions/08.2025.1 - Delegates.md
@@ -40,7 +40,7 @@ WCA Delegate is a role defined in the WCA Regulations to oversee official WCA Co
       1. Full trustworthiness.
       2. Excellent living knowledge of the Mission, Spirit, Policies, and Regulations of the WCA.
       3. Strong, independent, communicative, positive personality.
-      4. Leadership with strong feeling of responsibility.
+      4. Leadership with a strong feeling of responsibility.
       5. Organizational skills, ability to perform core organizational tasks if necessary.
       6. Representativeness for the WCA.
    3. Senior Delegates decide at any time which persons are proposed as WCA Delegates, and follow the appointment/nomination process per the Senior Delegate motion.

--- a/documents/motions/10.2024.12 - Archive Team.md
+++ b/documents/motions/10.2024.12 - Archive Team.md
@@ -11,7 +11,7 @@
 The WCA Archive Team is an Advisory Committee of the WCA with the role to oversee and support the development of an archive of the organization.
 
 1. The WCA Archive Team has the following rights and duties:
-   1. Developing a database of history of the WCA as an organization.
+   1. Developing a database of the history of the WCA as an organization.
    2. Developing a history of past major WCA Championship events.
    3. Assisting with the creation of promotional activities at Major Championship events in collaboration with the WCA Marketing Team and WCA Communication Team.
    4. Developing a history of notable WCA results.

--- a/documents/motions/10.2025.0 - Committees and Teams.md
+++ b/documents/motions/10.2025.0 - Committees and Teams.md
@@ -39,7 +39,7 @@ The WCA will have Committees and/or Teams that have the role of Advisory Committ
          1. The maximum extension is 24 months.
          2. The maximum appointment length is 48 months.
          3. Time spent as an interim Leader does not count towards the above extension restrictions. 
-      3. The WCA Board shall have the right to withdraw the appointment of a Committee Leader, if the Committee Leader does not comply with the rights and duties of Committee Leader, after advisory consultation by the WCA Integrity Committee.
+      3. The WCA Board shall have the right to withdraw the appointment of a Committee Leader, if the Committee Leader does not comply with the rights and duties of the Committee Leader, after advisory consultation by the WCA Integrity Committee.
          1. For the withdrawal of the WCA Integrity Committee Leader, the WCA Board will ask for advisory consultation by the WCA Appeals Committee.
          2. If none of these consultations is possible due to the inexistence of these Committees or because these Committees are not functional, the WCA Board will proceed without consultation.
       4. After a Committee Leader appointment has been withdrawn, the person remains as a Committee/Team Senior Member of the respective Committee/Team.

--- a/documents/motions/10.2025.1 - Communication Team.md
+++ b/documents/motions/10.2025.1 - Communication Team.md
@@ -18,7 +18,7 @@ The WCA Communication Team is an Advisory Committee of the WCA with the role to 
    4. Creating and publishing general content of the WCA via social media and other communication channels.
    5. Managing the media and media hyperlinks uploaded by users to the WCA website.
    6. Preventing and solving cases of unauthorized or incorrect use of WCA content and references.
-   7. Maintaining and publishing information that addresses frequently asked questions from the general public and WCA Vounteers.
+   7. Maintaining and publishing information that addresses frequently asked questions from the general public and WCA Volunteers.
    8. Handling communication with the general public regarding general information requests, frequently asked questions, and incorrectly addressed communication.
    9. Establishing and maintaining communication channels between the WCA Community and the WCA Board, providing feedback from Registered Speedcubers about the WCA operations.
    10. Additional duties as directed by the WCA Board.

--- a/documents/motions/10.2025.4 - Appeals Committee.md
+++ b/documents/motions/10.2025.4 - Appeals Committee.md
@@ -32,5 +32,5 @@ The WCA Appeals Committee is an Advisory Committee of the WCA.
       1. Exception: If the Board is temporarily required to lead the WCA Integrity Committee and/or the WCA Appeals Committee, due to that Committee not having a Leader, there may be an overlap in members of the WCA Board and that Committee.
    2. If both bodies are constituted and functional there must not exist an overlap in members of the WCA Regulations Committee and the WCA Appeals Committee.
 6. Eligibility for membership:
-   1. To be eligble to serve as a member of the WCA Appeals Committee the candidate must have served a period of at least 12 consecutive months as a WCA Volunteer.
+   1. To be eligible to serve as a member of the WCA Appeals Committee the candidate must have served a period of at least 12 consecutive months as a WCA Volunteer.
       1. Candidates do not need to be a current WCA Volunteer at the time of their appointment.

--- a/documents/motions/13.2025.1 - Amendments of Motions.md
+++ b/documents/motions/13.2025.1 - Amendments of Motions.md
@@ -24,7 +24,7 @@
       1. All the WCA Members with voting rights at the start of the voting are eligible to vote.
       2. There must be an effective participation strictly above 50% of the total eligible voters for the voting to be considered valid.
       3. If the WCA Voting Members do not approve the Motions, the process will stop.
-      4. The WCA Board may chose to split the approval vote into multiple votes for distinct sets of changes. In such a case:
+      4. The WCA Board may choose to split the approval vote into multiple votes for distinct sets of changes. In such a case:
          1. The documents prepared in line with 2.5.2 and 2.5.3 must indicate to which set each change relates, and summarise the changes included in each set.
          2. The clauses 2.7.2 and 2.7.3 apply to each set of changes individually. 
    8. The approved Motions and Amendments of the Motions must be announced and made publicly accessible via the online services of the WCA.

--- a/documents/motions/15.2025.1 - Suspensions and other Sanctions.md
+++ b/documents/motions/15.2025.1 - Suspensions and other Sanctions.md
@@ -15,7 +15,7 @@
       1. Fines must only be issued if acts of the Community member caused financial damage or financial loss to the WCA or any organization or individual within the WCA Community.
       2. The fine must not be larger than the actual damage or loss.
    4. to issue fines against a WCA Regional Organization and suspend a Regional Organization member from hosting WCA Competitions or attending WCA Meetings until the fines are paid.
-      1. Fines must only be issued if acts of the Regional Organization caused financial damage or financial loss to the WCA or any organization or individual within WCA Community.
+      1. Fines must only be issued if acts of the Regional Organization caused financial damage or financial loss to the WCA or any organization or individual within the WCA Community.
       2. The fine must not be larger than the actual damage or loss.
    5. to withhold or withdraw prizes and honors (records, titles, medals, certificates) from a Registered Speedcuber.
    6. to disqualify a Registered Speedcuber or specific results of a Registered Speedcuber during and/or after a WCA Competition.
@@ -33,10 +33,10 @@
    1. to suspend a Community member from participation in or attendance of a WCA Competition or specific events of WCA Competitions, for a fixed period or until a specified set of circumstances changes or ceases to exist.
    2. to caution or censure a Community member.
    3. to issue fines against a Community member and suspend them from participation in a WCA Competition until the fines are paid.
-      1. Fines must only be issued if acts of the Community member caused financial damage or financial loss to the WCA or any organization or individual within WCA Community.
+      1. Fines must only be issued if acts of the Community member caused financial damage or financial loss to the WCA or any organization or individual within the WCA Community.
       2. The fine must not be larger than the actual damage or loss.
    4. to issue fines against a WCA Regional Organization and suspend a Regional Organization member from hosting WCA Competitions or attending WCA Meetings until the fines are paid.
-      1. Fines must only be issued if acts of the Regional Organization caused financial damage or financial loss to the WCA or any organization or individual within WCA Community.
+      1. Fines must only be issued if acts of the Regional Organization caused financial damage or financial loss to the WCA or any organization or individual within the WCA Community.
       2. The fine must not be larger than the actual damage or loss.
    5. to withhold or withdraw prizes and honors (records, titles, medals, certificates) from a Registered Speedcuber.
    6. to disqualify a Registered Speedcuber or specific results of a Registered Speedcuber during and/or after a WCA Competition.

--- a/documents/motions/16.2025.1 - Disputes.md
+++ b/documents/motions/16.2025.1 - Disputes.md
@@ -34,7 +34,7 @@
       1. The WCA Appeals Committee determines that the original committee did not conduct a proper decision making process in making their final decision. This includes but is not limited to negligence and conflict of interest.
       2. The decision taken by the original Committee is not in accordance with the WCA Regulations, Motions, Policies or Bylaws.
       3. The WCA Appeals Committee uncovers new evidence that would have caused the original Committee to reach a different conclusion.
-   4. Once the WCA Appeals Committee has made their final decision the result of the appeal is communicated to the appealer, the original committee and all other interested parties.
+   4. Once the WCA Appeals Committee has made their final decision the result of the appeal is communicated to the appellant, the original committee and all other interested parties.
       1. A report of the appeal is sent to the original Committee and the WCA Board. 
 7. During the process of disputes and appeals all involved parties should be heard.
 8. The decisions on disputes and appeals will take immediate effect and all WCA Community members must take all necessary actions to ensure that the decisions come into effect.


### PR DESCRIPTION
* two cases of misspelled words ('volunteers' and 'eligible')
* one case of a verb in the wrong tense ('chose' -> 'choose')
* one case of an irregular word used when a more common word exists ('appealer' -> 'appellant')
* seven cases of missing articles ('a' or 'the')