### PR TITLE
Replace Staff with Volunteer in internal and external policies

### DIFF
--- a/documents/Code of Conduct.md
+++ b/documents/Code of Conduct.md
@@ -1,12 +1,12 @@
 # Code of Conduct
 
-### Version 1.1 {.version}
+### Version 1.2 {.version}
 
 The Code of Conduct must be considered by all members of the World Cube Association (WCA) Community, as a standard for actions and behavior. Members of the WCA Community include, but are not limited to: Registered Speedcubers, Competitions Organizers, Guests, WCA Officials, Users on the official WCA Forum. 
 
 These actions should uphold the Spirit and Mission of the WCA while not breaking any Regulations, Motions or Policies. 
 
-Registered Speedcubers who are qualified as “WCA Staff” must also uphold the Code of Ethics as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. 
+Registered Speedcubers who are qualified as WCA Volunteer must also uphold the Code of Ethics as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. 
 
 This Code covers previously known issues, as well as issues that the WCA foresees as requiring additional guidance. This document will be updated periodically to incorporate new topics as they are brought to the attention of the WCA, and will also be reviewed regularly. 
 

--- a/documents/Code of Conduct.md
+++ b/documents/Code of Conduct.md
@@ -2,11 +2,7 @@
 
 ### Version 1.2 {.version}
 
-The Code of Conduct must be considered by all members of the World Cube Association (WCA) Community, as a standard for actions and behavior. Members of the WCA Community include, but are not limited to: Registered Speedcubers, Competitions Organizers, Guests, WCA Officials, Users on the official WCA Forum. 
-
-These actions should uphold the Spirit and Mission of the WCA while not breaking any Regulations, Motions or Policies. 
-
-Registered Speedcubers who are qualified as WCA Volunteer must also uphold the Code of Ethics as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. 
+The Code of Conduct must be considered by all members of the World Cube Association (WCA) Community, as a standard for actions and behavior. These actions should uphold the Spirit and Mission of the WCA while not breaking any Regulations, Motions or Policies. 
 
 This Code covers previously known issues, as well as issues that the WCA foresees as requiring additional guidance. This document will be updated periodically to incorporate new topics as they are brought to the attention of the WCA, and will also be reviewed regularly. 
 

--- a/documents/Code of Conduct.md
+++ b/documents/Code of Conduct.md
@@ -8,7 +8,7 @@ This Code covers previously known issues, as well as issues that the WCA foresee
 
 Disciplinary procedures are handled by the WCA Integrity Committee (WIC) as outlined in item 3 of this document.
 
-The official communication channel for the WIC is via email. For any concerns about the conduct of Registered Speedcubers, contact the WIC: [integrity@worldcubeassociation.org](mailto:integrity@worldcubeassociation.org).
+The official communication channel for the WIC is via email. For any concerns about the conduct of a Member of the WCA Community, contact the WIC: [integrity@worldcubeassociation.org](mailto:integrity@worldcubeassociation.org).
 
 ::::: {.page-break-before}
 :::::
@@ -18,7 +18,7 @@ The official communication channel for the WIC is via email. For any concerns ab
       1. that it is their personal responsibility to familiarize themselves with all of the requirements of the Code of Conduct, including what conduct constitutes an offense under the Code of Conduct;
       2. to submit to the exclusive jurisdiction of any WCA Delegate, WCA Committee or WCA Board of Directors convened under the Disciplinary Procedure to hear and determine charges brought (and any appeals in relation thereto) pursuant to the Code of Conduct; and
       3. not to bring any proceedings to any court or other forum that are inconsistent with the foregoing submission to the jurisdiction of WCA Delegates, WCA Committees or WCA Board.
-   2. While taking into account Article 1.1, the WCA and Members of the WCA Community shall be responsible for promoting Code of Conduct awareness and education amongst Members of the WCA Community; in particular WCA Officials.
+   2. While taking into account Article 1.1, the WCA and Members of the WCA Community shall be responsible for promoting Code of Conduct awareness and education amongst Members of the WCA Community; in particular WCA Volunteers.
 2. **Conduct**
    1. Every member of the WCA Community must behave with respect towards the representatives of the WCA, other Registered Speedcubers, spectators, press and partners. This applies to behavior during WCA Competitions and also online, on official WCA platforms. Members of the WCA Community are expected to conduct themselves according to the following values:
       1. Compassion: treat others as you would like to be treated.
@@ -34,7 +34,7 @@ The official communication channel for the WIC is via email. For any concerns ab
       7. Advocating for, or encouraging, any of the above behavior.
    3. The status of the WCA as a 100% volunteer-run nonprofit must be upheld by all Community Members. This means that:
       1. Finances for WCA Competitions must be handled according to the WCA Code of Ethics, section “Finances”.
-      2. Leftover money must not be retained by Organizers who are not  Regional Organizations or WCA Delegates, who must abide by the Code of Ethics (2.3.1). Leftover money shall thus be reinvested and used for Community activities.
+      2. Leftover money must not be retained by Organizers who are not Regional Organizations or WCA Delegates, who must abide by the Code of Ethics (2.3.1). Leftover money shall thus be reinvested and used for Community activities.
 3. **Disciplinary Procedure**
    1. Violations of the Code of Conduct will be analyzed and evaluated by the WCA Integrity Committee.
    2. Violations of the Code of Conduct can result in Suspensions and other Sanctions.

--- a/documents/Code of Ethics.md
+++ b/documents/Code of Ethics.md
@@ -1,20 +1,20 @@
 # Code of Ethics
 
-### Version 2.5 {.version}
+### Version 2.6 {.version}
 
-The Code of Ethics must be considered by all Staff members of the World Cube Association (WCA), referred to in this document as “WCA Staff”, as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. “Listed Delegates” refers to WCA Delegates who are publicly displayed on the “General info” tab of an official WCA Competition.
+The Code of Ethics must be considered by all World Cube Association (WCA) Volunteers as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. “Listed Delegates” refers to WCA Delegates who are publicly displayed on the “General info” tab of an official WCA Competition.
 
-These actions and decisions should be made in such a manner that, if consistently performed by WCA Staff, the [Spirit and Mission](wcadoc{documents/motions/01.2021.1 - Spirit.pdf}) of the WCA would continue to be upheld while not breaking any [Regulations](wca{regulations}), [Motions, or Policies](wca{documents}).
+These actions and decisions should be made in such a manner that, if consistently performed by WCA Volunteers, the [Spirit and Mission](wcadoc{documents/motions/01.2021.1 - Spirit.pdf}) of the WCA would continue to be upheld while not breaking any [Regulations](wca{regulations}), [Motions, or Policies](wca{documents}).
 
 This Code covers previously known issues, as well as issues that the WCA Integrity Committee (WIC) foresees as requiring additional guidance. This document will be updated periodically to incorporate new topics as they are brought to the attention of the WIC, and will also be reviewed regularly.
 
-The official communication channel for the WIC is via email. For any concerns about the ethical conduct of a WCA Staff member, contact the WIC: [integrity@worldcubeassociation.org](mailto:integrity@worldcubeassociation.org). If there are any concerns about the ethical conduct of the WCA Integrity Committee, either the Committee itself or an individual member, please contact the WCA Appeals Committee (WAC) at: [appeals@worldcubeassociation.org](mailto:appeals@worldcubeassociation.org).
+The official communication channel for the WIC is via email. For any concerns about the ethical conduct of a WCA Volunteer, contact the WIC: [integrity@worldcubeassociation.org](mailto:integrity@worldcubeassociation.org). If there are any concerns about the ethical conduct of the WCA Integrity Committee, either the Committee itself or an individual member, please contact the WCA Appeals Committee (WAC) at: [appeals@worldcubeassociation.org](mailto:appeals@worldcubeassociation.org).
 
 ::::: {.page-break-before}
 :::::
 
 1. **Finances**
-   1. WCA Staff must not use money, discounts, or goods obtained from their role within the WCA for personal profit.
+   1. WCA Volunteers must not use money, discounts, or goods obtained from their role within the WCA for personal profit.
       1. Examples include:
          1. Competitor fees
          2. Equipment
@@ -44,13 +44,13 @@ The official communication channel for the WIC is via email. For any concerns ab
 2. **Communication**
    1. The [WCA email account policy](wcadoc{documents/policies/internal/Email%20Account.pdf}) must be followed.
       1. All official WCA email communication must utilize the @worldcubeassociation.org addresses.
-      2. WCA Staff must be aware that emails sent from @worldcubeassociation.org email addresses to external parties may be perceived as being on behalf of the WCA. Personal email addresses should be used to avoid this perception.
+      2. WCA Volunteers must be aware that emails sent from @worldcubeassociation.org email addresses to external parties may be perceived as being on behalf of the WCA. Personal email addresses should be used to avoid this perception.
          1. Example: Contacting sponsors for a competition should use personal email addresses.
    2. WCA Delegates must communicate with other Delegates in their region and/or in any region they are planning to delegate a competition.
-   3. All work done within the WCA is confidential and must not be disclosed to non-WCA Staff members without explicit permission from relevant members.
+   3. All work done within the WCA is confidential and must not be disclosed to non-WCA Volunteers without explicit permission from relevant members.
       1. Delegates may provide relevant feedback to the Organizers but must not give visibility of sensitive information, or sections written by other Delegates.
-   4. WCA Staff should be professional, respectful, and provide a positive reflection of the organization.
-      1. WCA Staff should always be aware of their target audience (e.g. their age, experience, nationality, etc.) and their tone/language when they make statements while acting in their capacity as WCA Staff.
+   4. WCA Volunteers should be professional, respectful, and provide a positive reflection of the organization.
+      1. WCA Volunteers should always be aware of their target audience (e.g. their age, experience, nationality, etc.) and their tone/language when they make statements while acting in their capacity as a WCA Volunteer.
 3. **Conduct of Official WCA Competitions**
    1. Decisions on incidents required to be made by a WCA Delegate must only be made by those listed on the WCA competition page.
       1. Non-listed Delegates and non-Delegates can make decisions on incidents only with the approval of the listed Delegate(s).
@@ -67,30 +67,30 @@ The official communication channel for the WIC is via email. For any concerns ab
    4. Delegates and Organizers should only be officially listed for a competition if they perform a significant role.
       1. Delegates and Organizers should agree on their roles for the competition before the competition is announced.
 4. **Conflicts of Interest**
-   1. WCA Staff must report all potential conflicts of interest that may arise and affect their WCA Staff role to the WIC using [this form](https://docs.google.com/forms/d/e/1FAIpQLSca81GIwjguJoWrPcbgabkRpdgJqbusIf9RBR7ObNNNL9kvqw/viewform?usp=sf_link). These include, but are not limited to:
+   1. WCA Volunteers must report all potential conflicts of interest that may arise and affect their WCA Volunteer role to the WIC using [this form](https://docs.google.com/forms/d/e/1FAIpQLSca81GIwjguJoWrPcbgabkRpdgJqbusIf9RBR7ObNNNL9kvqw/viewform?usp=sf_link). These include, but are not limited to:
       1. Sponsorships
       2. A stake in businesses trading within the cubing community.
          1. Example: Being the owner of a cubing store/business.
-   2. WCA Staff must not receive sponsorship(s) for their role within the WCA.
-      1. Any sponsorship details of a WCA Staff member as a competitor must be reported to the WIC.
-   3. WCA Staff must not use their role to promote a third party brand who are not a [WCA-recognized regional organization](wca{organizations}), the competition sponsor(s), or sponsors of the WCA. This includes but is not limited to:
+   2. WCA Volunteers must not receive sponsorship(s) for their role within the WCA.
+      1. Any sponsorship details of a WCA Volunteer as a competitor must be reported to the WIC.
+   3. WCA Volunteers must not use their role to promote a third party brand who are not a [WCA-recognized regional organization](wca{organizations}), the competition sponsor(s), or sponsors of the WCA. This includes but is not limited to:
       1. Promotions in emails to competitors
       2. References in the email signature block
    4. Listed WCA Delegates must not wear apparel which could reasonably be interpreted as an official affiliation or agreement with the WCA.
       1. Delegates may wear personal sponsorship apparel while they are competing.
    5. Organizers must handle decisions on competition sponsors.
       1. Delegates may provide advice and should ensure that the competition organization team is negotiating a fair deal.
-   6. WCA Staff must take all steps possible to exclude themselves from any decisions in which they have a conflict of interest.
+   6. WCA Volunteers must take all steps possible to exclude themselves from any decisions in which they have a conflict of interest.
 5. **Abuse of Power**
-   1. A WCA Staff member must not use their power within the organization/community to unfairly benefit an individual or group, including, but not limited to:
+   1. A WCA Volunteers member must not use their power within the organization/community to unfairly benefit an individual or group, including, but not limited to:
       1. Monetary benefit
       2. Benefit of personal results
       3. Increase in internal position
-   2. A WCA Staff member must not use their power within the organization/community to unfairly harm an individual or group, including, but not limited to:
+   2. WCA Volunteers must not use their power within the organization/community to unfairly harm an individual or group, including, but not limited to:
       1. Disqualification of results
       2. Unfair conditions at competitions
       3. Unfair treatment of competitors
-   3. WCA Staff must not use their permissions to take actions which are outside of the scope of their role within the WCA.
-   4. WCA Staff must not sign contracts on behalf of the WCA without prior approval of the WCA Board. Written permission from the Board is required to have the WCA referenced in a contract.
+   3. WCA Volunteers must not use their permissions to take actions which are outside of the scope of their role within the WCA.
+   4. WCA Volunteers must not sign contracts on behalf of the WCA without prior approval of the WCA Board. Written permission from the Board is required to have the WCA referenced in a contract.
       1. This includes presenting the WCA’s IRS Determination letter or using the WCA’s non-profit status as part of the organization of a competition.
-      2. WCA Staff may prove their role to 3rd parties (such as venues) by requesting the Board of Directors for a document with the WCA's letterhead.
+      2. WCA Volunteers may prove their role to 3rd parties (such as venues) by requesting the Board of Directors for a document with the WCA's letterhead.

--- a/documents/policies/external/Competition Requirements.md
+++ b/documents/policies/external/Competition Requirements.md
@@ -1,6 +1,6 @@
 # WCA Competition Requirements Policy
 
-### Version 5.3 {.version}
+### Version 5.4 {.version}
 
 ## Purpose
 The purpose of this policy is to define the requirements and processes that a competition must meet and follow in order to be recognized as a WCA Competition.

--- a/documents/policies/external/Competition Requirements.md
+++ b/documents/policies/external/Competition Requirements.md
@@ -80,7 +80,7 @@ The WCA Delegate must submit the following information when requesting approval 
         3. A commonly used demonym of the region or its residents,
         4. Local language specific to the region,
         5. Other locational identifiers may be accepted at the discretion of the WCAT.
-   8. Competitions may not be named after a living cuber, member of the organization team, or any competition staff, including pseudonyms or online tags of such people.
+   8. Competitions may not be named after a living cuber, member of the organization team, or any competition volunteers, including pseudonyms or online tags of such people.
    9. Names must not contain possibly offensive parts or memes.
    10. The name cannot contain website domains or anything susceptible to be interpreted as a link, hashtag or in general an electronic identifier.
    11. The name cannot contain any trademarks unless the organization team is formally authorized, in writing, to use such names.
@@ -197,7 +197,7 @@ The WCA Delegate must submit the following information when requesting approval 
       2. A round of an event must have planned advancement conditions if there is a subsequent round of the event.
       3. A round may have a cutoff. A round with a cutoff is a cutoff round, with the formats as outlined in [WCA Regulation 9b)](wca{regulations/#9b}).
    2. Only results from events that appear on the competition website in the Events tab and Schedule will be recognized.
-      1. Groups held for smaller subsections of competitors (e.g., competition staff), at a different time than the rest of the round, must be highlighted in the schedule.
+      1. Groups held for smaller subsections of competitors (e.g., competition volunteers), at a different time than the rest of the round, must be highlighted in the schedule.
          1.  The competition delegates should carefully consider the fairness and need when reviewing such schedules.
       2. Other events may only be held unofficially.
    3. The winner of the main event of the competition should be considered the overall winner of the competition.

--- a/documents/policies/external/Equipment Funding.md
+++ b/documents/policies/external/Equipment Funding.md
@@ -1,6 +1,6 @@
 # WCA Equipment Funding Policy
 
-### Version 2.1 {.version}
+### Version 2.2 {.version}
 
 ## Purpose
 The purpose of this policy is to offer a set of procedures by which the WCA can invest in the equipment necessary to run WCA Competitions in regions where their own ability to obtain equipment is hindered by financial obstacles, in order to further the Mission and the Spirit of the WCA.

--- a/documents/policies/external/Equipment Funding.md
+++ b/documents/policies/external/Equipment Funding.md
@@ -36,9 +36,9 @@ An application for funding must be submitted by a WCA Delegate or acknowledged W
 3. For all equipment that is not timing equipment, the cost of the equipment along with documentation of the cost.
 4. An explanation of why they are not able to purchase the equipment themselves or the conflicting financial priorities that would have to be sacrificed to purchase the equipment.
 5. An estimate of how often the equipment will be used for WCA Competitions. 
-6. The WCA Staff, Trainee Delegate or Regional Organization who will act as custodian for the equipment. 
+6. The WCA Volunteer, Trainee Delegate or Regional Organization who will act as custodian for the equipment. 
 
-The WCA Financial Committee (WFC) will evaluate the application, asking for assistance from the WCA Board of Directors, other WCA Committee or Teams, WCA Staff Members, or outside sources as needed. Once the application has been researched and considered, the WFC will vote on whether to fund the requested equipment fully, partially, or not at all. The WFC will then inform the applicant of the decision.
+The WCA Financial Committee (WFC) will evaluate the application, asking for assistance from the WCA Board of Directors, other WCA Committee or Teams, WCA Volunteers, or outside sources as needed. Once the application has been researched and considered, the WFC will vote on whether to fund the requested equipment fully, partially, or not at all. The WFC will then inform the applicant of the decision.
 
 The funding decision for each application will be made on a case-by-case basis depending on the merits of the application and the budgeted amount for equipment approved by the WCA Board of Directors.
 
@@ -50,7 +50,7 @@ The method of procuring the equipment will vary. The WCA will use one of the fol
 3. Making an advance of funds to the applicant for purchasing the equipment themselves. In this case, the applicant must purchase the equipment, provide all receipts, and refund any funds not used for the equipment purchase within 30 days of receiving the advance. Failure to use the funds for the purpose they have been provided may lead to WCA disciplinary procedures and/or legal action.
 
 ### Equipment Custodian
-The WCA will remain the owner of the purchased equipment and reserves the right to require its return (at the expense of the WCA) at any time. However, as part of the application process, one or more custodians will be approved by the WFC to hold, maintain, and care for the equipment. A custodian must be a WCA Staff Member, a WCA Trainee Delegate, or an acknowledged WCA Regional Organization. 
+The WCA will remain the owner of the purchased equipment and reserves the right to require its return (at the expense of the WCA) at any time. However, as part of the application process, one or more custodians will be approved by the WFC to hold, maintain, and care for the equipment. A custodian must be a WCA Volunteer, a WCA Trainee Delegate, or an acknowledged WCA Regional Organization. 
 
 Risk for any loss or damage to the equipment passes to the custodian upon delivery, and any loss or damage must be promptly reported to the WFC. Equipment custodians are expected to take proper care of equipment (though regular wear and tear is expected) and remain accountable for loss or damage even if it is temporarily loaned to another Delegate or organizer. The custodian will also be responsible for promptly responding to any inquiries from the WFC about the status, location, and use of the equipment. 
 

--- a/documents/policies/external/Logo Usage.md
+++ b/documents/policies/external/Logo Usage.md
@@ -1,6 +1,6 @@
 # WCA Logo Usage Policy
 
-### Version 2.0 {.version}
+### Version 2.1 {.version}
 
 ## Purpose
 
@@ -14,9 +14,9 @@ The logo covered by this policy is the [logo registered with the US Patent and T
 
 The registered symbol (®) must be included in all contexts and jurisdictions where the logo is used.
 
-### WCA Staff
+### WCA Volunteers
 
-Members of WCA Staff may use the WCA logo on internal documents, presentations, and other materials related to their work for the WCA.
+WCA Volunteers may use the WCA logo on internal documents, presentations, and other materials related to their work for the WCA.
 
 ### WCA Competitions
 

--- a/documents/policies/external/Regional Restrictions.md
+++ b/documents/policies/external/Regional Restrictions.md
@@ -22,7 +22,7 @@ The purpose of this policy is to list the financial and other restrictions which
    7. Residents of the region are not eligible to receive funding through the WCA Travel Reimbursement Policy.
    8. Travel to and from the region is not eligible for funding through the WCA Travel Reimbursement Policy.
 4. The WCA Board may apply further restrictions in addition to financial restrictions, which will be listed in this policy.
-5. Regional restrictions are placed by the WCA Board by updating Appendix A of this policy, in consultation with the WCA Financial Committee and other applicable WCA Staff or advisors.
+5. Regional restrictions are placed by the WCA Board by updating Appendix A of this policy, in consultation with the WCA Financial Committee and other applicable WCA Volunteers or advisors.
 
 ## Appendix A {.page-break-before}
 ### List of Regions with Restrictions

--- a/documents/policies/external/Regional Restrictions.md
+++ b/documents/policies/external/Regional Restrictions.md
@@ -1,6 +1,6 @@
 # WCA Regional Restrictions Policy
 
-### Version 1.1 {.version}
+### Version 1.2 {.version}
 
 ## Purpose
 The purpose of this policy is to list the financial and other restrictions which the WCA applies to specific regions.

--- a/documents/policies/external/Travel Reimbursement.md
+++ b/documents/policies/external/Travel Reimbursement.md
@@ -3,7 +3,7 @@
 ### Version 2.0 {.version}
 
 ## Purpose
-The purpose of this policy is to define the conditions under which the travel expenses of World Cube Association (WCA) Staff can be paid by the organization in order to further the Mission and the Spirit of the WCA.
+The purpose of this policy is to define the conditions under which the travel expenses of World Cube Association (WCA) Volunteers can be paid by the organization in order to further the Mission and the Spirit of the WCA.
 
 ## Policy
 ### Allowable Expenses
@@ -29,7 +29,7 @@ The purpose of this policy is to define the conditions under which the travel ex
    3. Alaska, Hawaii, and US territories – [US Department of Defense OCONUS Per Diem Rates](https://www.travel.dod.mil/Travel-Transportation-Rates/Per-Diem/Per-Diem-Rate-Lookup/)
 2. Lodging expenses for travel to a competition can only be claimed for the night before a competition begins, nights during a competition, and the night after a competition ends. Lodging expenses for travel on official WCA business outside of a competition can only be claimed for nights before or after days where WCA business is undertaken.
 3. Meal expenses can only be claimed for days during a competition, days during which official WCA business is undertaken, or days on which WCA-funded travel is taking place.
-4. If anyone not explicitly named and authorized for WCA-funded travel is charged for a meal on the same receipt as someone whose travel is being funded, the meal expense must be prorated to only cover the portion of the food for the funded staff member(s) and a prorated portion of the tip (if applicable).
+4. If anyone not explicitly named and authorized for WCA-funded travel is charged for a meal on the same receipt as someone whose travel is being funded, the meal expense must be prorated to only cover the portion of the food for the funded WCA Volunteer(s) and a prorated portion of the tip (if applicable).
 5. Tips can be claimed as a meal expense but do count against the total daily meal expense limit.
 6. Alcohol cannot be claimed as a meal expense.
    

--- a/documents/policies/external/Travel Reimbursement.md
+++ b/documents/policies/external/Travel Reimbursement.md
@@ -1,6 +1,6 @@
 # WCA Travel Reimbursement Policy
 
-### Version 2.0 {.version}
+### Version 2.1 {.version}
 
 ## Purpose
 The purpose of this policy is to define the conditions under which the travel expenses of World Cube Association (WCA) Volunteers can be paid by the organization in order to further the Mission and the Spirit of the WCA.

--- a/documents/policies/internal/Delegate Probationary Status.md
+++ b/documents/policies/internal/Delegate Probationary Status.md
@@ -22,7 +22,7 @@ Delegates who have late outstanding payments for competition Dues or gear orders
 ### Probation Due to Quality Issues
 At the discretion of the Senior Delegate, Delegates may be placed on probation due to quality issues, including, but not limited to:
 
-- Failure to reply to or communicate with WCA Staff members
+- Failure to reply to or communicate with WCA Volunteers
 - Failure to process WCA ID claims in a reasonable timeframe
 - Repeated carelessness when submitting competitions for announcement
 - Repeated carelessness when submitting competition results or corrections

--- a/documents/policies/internal/Delegate Probationary Status.md
+++ b/documents/policies/internal/Delegate Probationary Status.md
@@ -1,6 +1,6 @@
 # WCA Delegate Probationary Status Policy
 
-### Version 1.4 {.version}
+### Version 1.5 {.version}
 
 ## Policy
 Delegates who fail to do their duties may be placed on probation. This is an internal designation which only the Delegate on probation, Regional Delegate, Senior Delegate, Board, and relevant committees and/or teams would be aware of.

--- a/documents/policies/internal/Email Account.md
+++ b/documents/policies/internal/Email Account.md
@@ -3,45 +3,47 @@
 ### Version 1.2 {.version}
 
 ## Purpose
-The purpose of this policy is to outline the guidelines and requirements of individual user accounts and group accounts on the worldcubeassociation.org domain. This policy applies to all WCA Staff members and anyone else who is assigned (or given access to) a corporate email. Since Staff who use WCA email are representing the World Cube Association, they must be aware that they represent the WCA whenever they send emails from such an account.
+The purpose of this policy is to outline the guidelines and requirements of individual user accounts and group accounts on the worldcubeassociation.org domain. This policy applies to all WCA Volunteers and anyone else who is assigned (or given access to) a corporate email. Since WCA Volunteers who use WCA email are representing the World Cube Association, they must be aware that they represent the WCA whenever they send emails from such an account.
 
 ## Policy
-All WCA Staff must have a valid email address linked to an account on worldcubeassociation.org. This account is assigned by a G Suite administrator and must be claimed and linked before the Staff member is appointed on the WCA website.
+All WCA Volunteers must have a valid email address linked to an account on worldcubeassociation.org. This account is assigned by a G Suite administrator and must be claimed and linked before the WCA Volunteer is appointed on the WCA website.
 
 ### Appropriate Use
-Staff are required to use their WCA email for all official World Cube Association related business. Staff must adhere to this policy at all times. Staff must also adhere to all confidentiality and data protection guidelines. Staff may use their email to:
+WCA Volunteers are required to use their WCA email for all official World Cube Association related business and must adhere to this policy at all times. WCA Volunteers may use their email to:
 
-- Communicate as a WCA representative to community members, other Staff members, and partners
+- Communicate as a WCA representative to community members, other WCA Volunteers, and partners
 - Communicate as an organizer of WCA Competitions
-- Sign up or log in to services related to work as a WCA Staff member
-- Sign up for newsletters, platforms, or other services that will help them with their role as a WCA Staff member
+- Sign up or log in to services related to participate as a WCA Volunteer
+- Sign up for newsletters, platforms, or other services that will help them with their role as a WCA Volunteer
+
+ WCA Volunteers must adhere to all relevant confidentiality and data protection guidelines.
 
 ### Inappropriate Use
-Staff must not use their WCA email to:
+WCA Volunteers must not use their WCA email to:
 
 - Sign up for illegal, unreliable, disreputable, or suspect websites or services
 - Send unauthorized marketing content or solicitation emails
 - Send insulting or discriminatory messages or content
-- Intentionally spam other people’s emails, including other Staff members
+- Intentionally spam other people’s emails, including other WCA Volunteers
 
 ### Personal Use
-Staff should not use their WCA email for personal reasons.
+WCA Volunteers should not use their WCA email for personal reasons.
 
 ### Email Signature
-Staff are encouraged to create a professional email signature. Staff email signatures should not contain logos or unnecessary textual references. Here is a sample acceptable email signature:  
+WCA Volunteers are encouraged to create a professional email signature. The email signatures should not contain logos or unnecessary textual references. Here is a sample acceptable email signature:  
 **Mike Miller**  
 *Member of the WCA Results Team*  
 *WCA Delegate for United States (New York)*
 
 ### Disciplinary Action
-Staff who do not adhere to this policy may face disciplinary action (including dismissal as Staff).
+WCA Volunteers who do not adhere to this policy may face disciplinary action (including dismissal from their volunteer role).
 
 ### Account Deletion and Suspension
 
-- When an individual is no longer a WCA Staff member, their WCA account shall be suspended.
-   - If an individual becomes a Staff member again, their account shall be reinstated.
+- When an individual is no longer a WCA Volunteer, their WCA account shall be suspended.
+   - If an individual becomes a WCA Volunteer again, their account shall be reinstated.
 - The WCA G Suite administrator reserves the right to delete WCA accounts in certain circumstances.
-   - After a period of 7 years after a Staff member’s access is revoked, their account (and all related account email) shall be deleted.
+   - After a period of 7 years after a WCA Volunteer’s access is revoked, their account (and all related account email) shall be deleted.
 
 ### Password resets
-Staff requiring a password reset must contact the WCA Executive Assistants Team.
+WCA Volunteers requiring a password reset must contact the WCA Executive Assistants Team.

--- a/documents/policies/internal/Email Account.md
+++ b/documents/policies/internal/Email Account.md
@@ -1,6 +1,6 @@
 # WCA Email Account Policy
 
-### Version 1.2 {.version}
+### Version 1.3 {.version}
 
 ## Purpose
 The purpose of this policy is to outline the guidelines and requirements of individual user accounts and group accounts on the worldcubeassociation.org domain. This policy applies to all WCA Volunteers and anyone else who is assigned (or given access to) a corporate email. Since WCA Volunteers who use WCA email are representing the World Cube Association, they must be aware that they represent the WCA whenever they send emails from such an account.

--- a/documents/policies/internal/Payment Authorization.md
+++ b/documents/policies/internal/Payment Authorization.md
@@ -3,22 +3,22 @@
 ### Version 1.1 {.version}
 
 ## Purpose
-The purpose of this policy is to outline the procedures for individual WCA Staff Members to make payments on behalf of the WCA, and to authorize specific individuals. 
+The purpose of this policy is to outline the procedures for individual WCA Volunteers to make payments on behalf of the WCA, and to authorize specific individuals. 
 
 ## Policy
 1. Ability to make Payments
-   1. Through the course of of their role, WCA Staff Members may gain the ability to make payments on behalf of the WCA (e.g. explicit access to a bank account or payment card details). This includes abilities with limited scope, such as access to an online service which has WCA payment details pre-linked.
-   2. As a general principle, WCA Staff Members should only grant the ability to make payments to other WCA Staff Members sparingly and when it is necessary for them to act in the scope of their role within the WCA.
-   3. The posession of payment ability does not authorize individual Staff Members to act in a manner which will cause the WCA to incur costs. 
-   4. WCA Staff Members who use their ability to make payments in a manner not in line with the WCA Bylaws, Motions, Policies (including this policy) and/or Codes are considered to have acted outside the scope of their role within the WCA. The WCA reserves the right to take action in line with the WCA Code of Ethics or applicable laws in such an instance. 
+   1. Through the course of of their role, WCA Volunteers may gain the ability to make payments on behalf of the WCA (e.g. explicit access to a bank account or payment card details). This includes abilities with limited scope, such as access to an online service which has WCA payment details pre-linked.
+   2. As a general principle, WCA Volunteers should only grant the ability to make payments to other WCA Volunteers sparingly and when it is necessary for them to act in the scope of their role within the WCA.
+   3. The posession of payment ability does not authorize individual WCA Volunteers to act in a manner which will cause the WCA to incur costs. 
+   4. WCA Volunteers who use their ability to make payments in a manner not in line with the WCA Bylaws, Motions, Policies (including this policy) and/or Codes are considered to have acted outside the scope of their role within the WCA. The WCA reserves the right to take action in line with the WCA Code of Ethics or applicable laws in such an instance. 
 2. Authority to make Payments
-   1. Specific individual Staff Members, or Staff Members with defined roles, have the authority to make payments.
-      1. Where an individual Staff Member is named, the role in which capacity they have authorization is specified. If the WCA Staff Member ceases to hold that role the authorization is considered invalid.
-   3. Staff Members with authority may make payments directly, or authorize another WCA Staff Member with payment ability in writing to make the payment on an individual transaction basis.
+   1. WCA Volunteers with defined roles or those specified in Appendix A, have the authority to make payments.
+      1. Where an individual WCA Volunteer is named, the role in which capacity they have authorization is specified. If the WCA Volunteer ceases to hold that role, the authorization is considered invalid.
+   3. WCA Volunteers with authority may make payments directly, or authorize another WCA Volunteer with payment ability in writing to make the payment on an individual transaction basis.
    4. Payment authorization is split into multiple payment categories, and individuals may have a different payment authorization level for different categories. The payment authorization level applies on a per-transaction basis.
    5. All payments above individual authorization levels must be authorized by the WCA Board.
 3. Conflicts of Interest
-   1. WCA Staff Members with payment authority may not authorize payment to themselves, an immediate relative, or an organization where they are a director, owner, or involved in the management of finances.
+   1. WCA Volunteers with payment authority may not authorize payment to themselves, an immediate relative, or an organization where they are a director, owner, or involved in the management of finances.
 4. Prior to authorizing a payment, individuals with payment authority must:
    1. Determine the payment category;
    2. Ensure the payment complies with (as applicable) the WCA Bylaws, the WCA Motions, WCA Policies, and/or the most recent applicable WCA Board approved budget;
@@ -48,7 +48,7 @@ All figures are in US Dollars. Transactions in foreign currencies should be conv
 
 ::: {.scaled-table}
 
-| Staff Member Name    | Individual Role     | Gear Team Orders | Championship Support | Travel Funding | Equipment Funding | RO Support | Other Contracts | Other Budget Items             |
+| WCA Volunteer Name    | Individual Role     | Gear Team Orders | Championship Support | Travel Funding | Equipment Funding | RO Support | Other Contracts | Other Budget Items             |
 | -------------------- | ------------------- | ---------------- | -------------------- | -------------- | ----------------- | ---------- | --------------- | ------------------------------ |
 | Blake Thompson       | WCA Board Member    | $10,000          | $50,000              | $5,000         | $10,000           | $5,000     | $10,000         | $5,000. $10,000 for legal fees | 
 | Raymond Goslow       | WCA Treasurer       | $10,000          | $50,000              | $5,000         | $10,000           | $5,000     | $10,000         | $5,000. $10,000 for legal fees |   

--- a/documents/policies/internal/Payment Authorization.md
+++ b/documents/policies/internal/Payment Authorization.md
@@ -1,6 +1,6 @@
 # WCA Payment Authorization Policy
 
-### Version 1.1 {.version}
+### Version 1.2 {.version}
 
 ## Purpose
 The purpose of this policy is to outline the procedures for individual WCA Volunteers to make payments on behalf of the WCA, and to authorize specific individuals. 

--- a/documents/policies/internal/Working Group Formation.md
+++ b/documents/policies/internal/Working Group Formation.md
@@ -1,6 +1,6 @@
 # WCA Working Group Formation Policy
 
-### Version 1.0 {.version}
+### Version 1.1 {.version}
 
 ## Purpose
 The purpose of this policy is to provide guidelines for the formation and operation of working groups within the World Cube Association (WCA) in order to facilitate collaboration, innovation, and progress in specific focus areas.

--- a/documents/policies/internal/Working Group Formation.md
+++ b/documents/policies/internal/Working Group Formation.md
@@ -7,9 +7,9 @@ The purpose of this policy is to provide guidelines for the formation and operat
 
 ## Policy
 1. Definition of a Working Group
-   1. A working group is a temporary team of WCA Staff and/or community members established to address a specific project or area of interest within the organization. Working groups are tasked with generating ideas, providing recommendations, and executing initiatives related to their assigned focus area
+   1. A working group is a temporary team of WCA Volunteers and/or community members established to address a specific project or area of interest within the organization. Working groups are tasked with generating ideas, providing recommendations, and executing initiatives related to their assigned focus area
 2. Formation
-   1. Working groups may be proposed by any WCA Staff member.
+   1. Working groups may be proposed by any WCA Volunteer.
    2. The Working group must be sponsored by a team leader, a Senior Delegate, a Director or an Officer.
    3.  Proposals for working groups should be submitted in writing to the Board of Directors for review and approval.
 3. Approval Process
@@ -20,7 +20,7 @@ The purpose of this policy is to provide guidelines for the formation and operat
    2. The leader will serve as the primary point of contact between the working group and the Board of Directors.
 5. Composition
    1. Each working group shall consist of a minimum of four (4) members, including a designated leader. 
-   2. The leader should determine the most appropriate membership for the specific working group.  The leader should consider if there should be representation from particular WCA teams or committees or if membership should be open to all WCA staff.
+   2. The leader should determine the most appropriate membership for the specific working group.  The leader should consider if there should be representation from particular WCA teams or committees or if membership should be open to all WCA Volunteers.
    3. Priority may be given to individuals with relevant expertise or experience. 
 6. Diversity and Inclusion
    1. The WCA is committed to fostering a diverse and inclusive environment. When forming working groups, efforts should be made to ensure representation from individuals from diverse backgrounds, with a wide range of perspectives, and experiences. This includes but is not limited to factors such as race, ethnicity, gender, age, sexual orientation, abilities, and socio-economic status. 


### PR DESCRIPTION
Following from #450 , all remaining WCA policies are being updated to remove the terms "WCA Staff" and  “Competition Staff” 