### PR TITLE
Documents Motion - Clerical Fix

### DIFF
--- a/documents/motions/21.2024.1 - WCA Documents.md
+++ b/documents/motions/21.2024.1 - WCA Documents.md
@@ -3,7 +3,7 @@
 **Motion number:** 21.2024.1  
 **Subject:** WCA Documents  
 **Intent:** Establish priorities and amendment procedures of WCA Documents  
-**Submitted by:** Motion has been removed and all responsibilities will be absorbed by the WCA Results Team.  
+**Submitted by:** WCA Board
 **Date:** August 1, 2024
 
 # Motion


### PR DESCRIPTION
The "Submitted by" section of the Documents Motion contains text that does not make sense in context. All other Motions say "WCA Board".

This text appears to have been included since the Motion was originally created ([PR](https://github.com/thewca/wca-documents/pull/218/files)).

This appears to be a drafting error. I believe it is suitable for correction as a clerical error under the Amendments of Motions Motion.