### PR TITLE
Working Group Policy Tweaks

### DIFF
--- a/documents/policies/internal/Working Group Formation.md
+++ b/documents/policies/internal/Working Group Formation.md
@@ -1,42 +1,41 @@
 # WCA Working Group Formation Policy
 
-### Version 1.1 {.version}
+### Version 1.2 {.version}
 
 ## Purpose
 The purpose of this policy is to provide guidelines for the formation and operation of working groups within the World Cube Association (WCA) in order to facilitate collaboration, innovation, and progress in specific focus areas.
 
 ## Policy
 1. Definition of a Working Group
-   1. A working group is a temporary team of WCA Volunteers and/or Community members established to address a specific project or area of interest within the organization. Working groups are tasked with generating ideas, providing recommendations, and executing initiatives related to their assigned focus area
+   1. A working group is a temporary team of WCA Volunteers and/or Community members established to address a specific project or area of interest within the organization. Working groups are tasked with generating ideas, providing recommendations, and executing initiatives related to their assigned focus area.
 2. Formation
    1. Working groups may be proposed by any WCA Volunteer.
-   2. The Working group must be sponsored by a team leader, a Senior Delegate, a Director or an Officer.
-   3.  Proposals for working groups should be submitted in writing to the Board of Directors for review and approval.
+   2. The Working group must be sponsored by a Committee/Team Leader, a Senior Delegate, a Director, or an Officer.
+   3. Proposals for working groups should be submitted in writing to the Board of Directors for review and approval.
 3. Approval Process
-   1. The Board of Directors will review proposed working groups and assess their alignment with the organization's mission, goals, and available resources.
+   1. The Board of Directors will review working group proposals and assess their alignment with the organization's mission, goals, and available resources.
    2. Approval will be granted based on the demonstrated need for the working group and its potential to positively impact the organization.
 4. Leadership
    1. Each working group shall have a designated leader responsible for coordinating meetings, setting agendas, and ensuring progress towards established goals.
    2. The leader will serve as the primary point of contact between the working group and the Board of Directors.
 5. Composition
-   1. Each working group shall consist of a minimum of four (4) members, including a designated leader. 
-   2. The leader should determine the most appropriate membership for the specific working group.  The leader should consider if there should be representation from particular WCA teams or committees or if membership should be open to all WCA Volunteers.
-   3. Priority may be given to individuals with relevant expertise or experience. 
+   1. Each working group shall consist of a minimum of four members, including a designated leader.
+   2. The leader should determine the most appropriate membership for the specific working group. The leader should consider if there should be representation from specific Committees/Teams, or if membership should be open to all WCA Volunteers.
 6. Diversity and Inclusion
-   1. The WCA is committed to fostering a diverse and inclusive environment. When forming working groups, efforts should be made to ensure representation from individuals from diverse backgrounds, with a wide range of perspectives, and experiences. This includes but is not limited to factors such as race, ethnicity, gender, age, sexual orientation, abilities, and socio-economic status. 
+   1. The WCA is committed to fostering a diverse and inclusive environment. When forming working groups, efforts should be made to ensure representation from individuals from diverse backgrounds, with a wide range of perspectives, and experiences. This includes but is not limited to factors such as race, ethnicity, gender, age, sexual orientation, abilities, and socio-economic status.
 7. Responsibilities of Working Group Members
    1. Members are expected to actively participate in meetings, contribute ideas and insights, and complete assigned tasks in a timely manner.
-   2. Members should communicate regularly with the working group leader and fellow members to ensure progress and address any challenges.
-8. Terms of Reference 
-   1. The working group must have a Terms of Reference (ToR) that is shared with the Board of Directors. The ToR is a crucial document that outlines the purpose, scope, and responsibilities of a working group. An example template can be found [here](https://docs.google.com/document/d/1du0LKmBeJlBNbzRjCoqmfEI5ILDNQ6FJYT9eowGLZGM/edit).
+   2. Members should maintain regular communication with the working group leader and fellow members to ensure progress and address any challenges.
+8. Terms of Reference
+   1. A working group must have a Terms of Reference (ToR) that is shared with the Board of Directors. The ToR is a crucial document that outlines the purpose, scope, and responsibilities of a working group. An example template can be found [here](https://docs.google.com/document/d/1du0LKmBeJlBNbzRjCoqmfEI5ILDNQ6FJYT9eowGLZGM/edit).
 9. Duration
    1. Working groups will have a defined term, typically not exceeding 12 months.
-   2. At the end of the term, the working group's progress and contributions will be evaluated, and a decision will be made regarding its continuation, modification, or dissolution.
+   2. At the end of the term, the Board of Directors will evaluate the working group’s progress and contributions, then determine whether to continue, modify, or dissolve the working group.
 10. Reporting and Accountability
     1. Working groups are required to provide regular updates to the Board of Directors on their activities, progress, and any challenges faced.
     2. The working group leader will be responsible for submitting these reports in a timely manner.
-    3. The working group should submit a final written report to the Board of Directors summarizing their findings. 
+    3. The working group should submit a final written report to the Board of Directors summarizing their findings.
 11. Conflict of Interest
-    1. Members of working groups must disclose all potential conflicts of interest that may arise during the course of their involvement.
+    1. Members of working groups must disclose all potential conflicts of interest that may arise during the course of their involvement to the WCA Integrity Committee using [this form](https://docs.google.com/forms/d/e/1FAIpQLSca81GIwjguJoWrPcbgabkRpdgJqbusIf9RBR7ObNNNL9kvqw/viewform).
 12. Dissolution
     1. The Board of Directors reserves the right to dissolve a working group if it is deemed no longer necessary or if it fails to meet its established objectives.

--- a/documents/policies/internal/Working Group Formation.md
+++ b/documents/policies/internal/Working Group Formation.md
@@ -21,6 +21,7 @@ The purpose of this policy is to provide guidelines for the formation and operat
 5. Composition
    1. Each working group shall consist of a minimum of four members, including a designated leader.
    2. The leader should determine the most appropriate membership for the specific working group. The leader should consider if there should be representation from specific Committees/Teams, or if membership should be open to all WCA Volunteers.
+   3. Priority may be given to individuals with relevant expertise or experience.
 6. Diversity and Inclusion
    1. The WCA is committed to fostering a diverse and inclusive environment. When forming working groups, efforts should be made to ensure representation from individuals from diverse backgrounds, with a wide range of perspectives, and experiences. This includes but is not limited to factors such as race, ethnicity, gender, age, sexual orientation, abilities, and socio-economic status.
 7. Responsibilities of Working Group Members


### PR DESCRIPTION
Slightly notable:
-Clarified that _the Board_ will evaluate the working group at the end of its term
-Clarified that conflicts of interests must be reported _to the WIC_ and linked the form

Others:
-Clerical fixes
-Aligned wording with Definitions
-Rephrasing for clarity
-Aligned stylization
-Edited ToR template to correctly abide by the WLUP