### PR TITLE
Committees and Teams Clerical - July 2025

### DIFF
--- a/documents/motions/10.2025.0 - Committees and Teams.md
+++ b/documents/motions/10.2025.0 - Committees and Teams.md
@@ -22,7 +22,7 @@ The WCA will have Committees and/or Teams that have the role of Advisory Committ
    3. The WCA Board may appoint an interim Leader for a period of up to 3 months without a request for applications among the Community.
          1. The selection of an interim Leader by the WCA Board is based on a vote in the WCA Board with at least a supermajority.
          2. It is not possible to extend the term of an interim Leader.
-         3. The term of an interim Leader automatically ends once a Leader is appointed by the WCA Board following the process outlined in section 4.2.
+         3. The term of an interim Leader automatically ends once a Leader is appointed by the WCA Board following the process outlined in section 5.2.
    4. The Committee Leader is responsible for:
       1. Making sure the Committee and the Committee Members are capable, equipped, and available for performing the duties of the Committee.
       2. Selecting, appointing, promoting, demoting, and removing Committee Members.


### PR DESCRIPTION
The reference to 4.2 in 5.3.3 should instead refer to 5.2. This appears to be a drafting error, as the correct reference would have been 4.2 in the version prior to the changes being introduced , see https://github.com/thewca/wca-documents/commit/5018d80a85858613340b2161efab0e9c5a7bca6f.