### PR TITLE
Broken link in table of contents

### DIFF
--- a/edudoc/delegate-handbook/delegate-handbook.md
+++ b/edudoc/delegate-handbook/delegate-handbook.md
@@ -24,7 +24,7 @@ There is a lot of information that is relevant to all WCA Volunteers, not just D
   - [Email](#email)
   - [Confidentiality](#confidentiality)
   - [Probation](#probation)
-  - [Lead Delegates](#lead-delegates)
+  - [Lead Delegate](#lead-delegate)
 - [Before the Competition](#before-the-competition)
   - [Competitions and Your Community](#competitions-and-your-community)
     - [Competition Frequency](#competition-frequency)


### PR DESCRIPTION
Just a quick fix to make the link go to the correct section.