### PR TITLE
Fix broken motion cross-reference links

### DIFF
--- a/documents/Code of Ethics.md
+++ b/documents/Code of Ethics.md
@@ -4,7 +4,7 @@
 
 The Code of Ethics must be considered by all WCA Volunteers as a standard for actions and decisions they will be making when acting on behalf of the WCA within their role. “Listed Delegates” refers to WCA Delegates who are publicly displayed on the “General info” tab of an official WCA Competition.
 
-These actions and decisions should be made in such a manner that, if consistently performed by WCA Volunteers, the [Spirit and Mission](wcadoc{documents/motions/01.2021.1 - Spirit.pdf}) of the WCA would continue to be upheld while not breaking any [Regulations](wca{regulations}), [Motions, or Policies](wca{documents}).
+These actions and decisions should be made in such a manner that, if consistently performed by WCA Volunteers, the [Spirit and Mission](wcadoc{documents/motions/01.2025.1 - Spirit.pdf}) of the WCA would continue to be upheld while not breaking any [Regulations](wca{regulations}), [Motions, or Policies](wca{documents}).
 
 This Code covers previously known issues, as well as issues that the WCA Integrity Committee (WIC) foresees as requiring additional guidance. This document will be updated periodically to incorporate new topics as they are brought to the attention of the WIC, and will also be reviewed regularly.
 

--- a/documents/motions/04.2025.1 - WCA Board.md
+++ b/documents/motions/04.2025.1 - WCA Board.md
@@ -18,7 +18,7 @@ The WCA Board of Directors is the leadership team of the WCA and its highest aut
    5. To mobilize WCA Volunteers, Regional Organizations, and Competition Organizers to organize WCA Competitions on local, national, continental, and world level, well distributed in time and geographical location, and to ensure the quality of WCA Competitions up to the maximum extent.
    6. To represent the WCA in dealings with other relevant organizations and with media.
    7. To negotiate or oversee the negotiation of all contracts on behalf of the WCA in consultation with the appropriate Committees.
-   8. To be accountable for the finances of the WCA, to oversee financial management of the WCA, and to ensure the WCA has sufficient procedures and resources to meet its financial obligations and regulatory requirements in accordance with the [WCA Motion : Finances](wca{documents/motions/11.2024.1 - Finances.pdf}).
+   8. To be accountable for the finances of the WCA, to oversee financial management of the WCA, and to ensure the WCA has sufficient procedures and resources to meet its financial obligations and regulatory requirements in accordance with the [WCA Motion : Finances](wcadoc{documents/motions/11.2025.1 - Finances.pdf}).
 2. The WCA Board has the following rights:
    1. To amend the Bylaws and their Motions. Such rights must be exercised in accordance with [WCA Motion : Amendments of Bylaws and Motions](wcadoc{documents/motions/13.2025.1 - Amendments of Motions.pdf}).
    2. To approve amendments to the Regulations. Such rights must be exercised in accordance with [WCA Motion : Amendments of Regulations](wcadoc{documents/motions/14.2025.1 - Amendments of Regulations.pdf}).

--- a/edudoc/volunteer-crash-course/volunteer_crash_course.md
+++ b/edudoc/volunteer-crash-course/volunteer_crash_course.md
@@ -9,9 +9,9 @@ Most of the important rules and common practices you need to know will be descri
 WCA Volunteers should be familiar with every document related to their work as WCA Volunteers. All relevant documents are on [the documents page](wca{documents}) and on [the Volunteer panel](wca{panel}). The Volunteer panel section is available only to WCA Volunteers and contains Volunteer-exclusive knowledge. Therefore, every document on that page should be read. The documents section contains information on how the WCA functions and is available to the public. Not every document in this section needs to be memorized. However, here are the ones that are absolutely necessary to know well:
 
 - [The Code of Ethics](wcadoc{documents/Code%20of%20Ethics.pdf}) describes how every WCA Volunteer must act and what they must abide by.
-- [The Spirit of the WCA](wcadoc{documents/motions/01.2021.1%20-%20Spirit.pdf}).
-- If you are a member of a Committee/Team, [The Committees and Teams Motion](wcadoc{documents/motions/10.2022.0%20-%20Committees%20and%20Teams.pdf}) will explain how Committees/Teams operate. Additionally, you will find the relevant motion for your Committee/Team among the other listed motions on the documents page.
-- If you are a Delegate, [The Delegates Motion](wcadoc{documents/motions/08.2022.1%20-%20Delegates.pdf}) will explain how your work as a Delegate will be conducted. You should also familiarize yourself with the [Delegate Handbook](wcadoc{edudoc/delegate-handbook/delegate-handbook.pdf}).
+- [The Spirit of the WCA](wcadoc{documents/motions/01.2025.1%20-%20Spirit.pdf}).
+- If you are a member of a Committee/Team, [The Committees and Teams Motion](wcadoc{documents/motions/10.2025.0%20-%20Committees%20and%20Teams.pdf}) will explain how Committees/Teams operate. Additionally, you will find the relevant motion for your Committee/Team among the other listed motions on the documents page.
+- If you are a Delegate, [The Delegates Motion](wcadoc{documents/motions/08.2025.1%20-%20Delegates.pdf}) will explain how your work as a Delegate will be conducted. You should also familiarize yourself with the [Delegate Handbook](wcadoc{edudoc/delegate-handbook/delegate-handbook.pdf}).
 
 ## Email
 


### PR DESCRIPTION
## Summary
Several documents link to motion PDFs using their **pre-2025 numbers**. After the motions were renumbered to the `*.2025.*` scheme, those old paths now return **403** on `documents.worldcubeassociation.org` (verified). This PR repoints them to the current files.

## Changes
| File | Old → New |
| --- | --- |
| `documents/Code of Ethics.md` | Spirit `01.2021.1` → `01.2025.1` |
| `edudoc/volunteer-crash-course/volunteer_crash_course.md` | Spirit `01.2021.1` → `01.2025.1`; Committees and Teams `10.2022.0` → `10.2025.0`; Delegates `08.2022.1` → `08.2025.1` |
| `documents/motions/04.2025.1 - WCA Board.md` | Finances `11.2024.1` → `11.2025.1`, **and** `wca{}` → `wcadoc{}` (the documents server, not the website) |