### PR TITLE
Fix grammar and subject/verb agreement

### DIFF
--- a/documents/Code of Conduct.md
+++ b/documents/Code of Conduct.md
@@ -18,7 +18,7 @@ The official communication channel for the WIC is via email. For any concerns ab
       1. that it is their personal responsibility to familiarize themselves with all of the requirements of the Code of Conduct, including what conduct constitutes an offense under the Code of Conduct;
       2. to submit to the exclusive jurisdiction of any WCA Delegate, WCA Committee or WCA Board of Directors convened under the Disciplinary Procedure to hear and determine charges brought (and any appeals in relation thereto) pursuant to the Code of Conduct; and
       3. not to bring any proceedings to any court or other forum that are inconsistent with the foregoing submission to the jurisdiction of WCA Delegates, WCA Committees or WCA Board.
-   2. While taking into account Article 1.1, the WCA and Community members shall be responsible for promoting Code of Conduct awareness and education amongst Community members; in particular WCA Volunteers.
+   2. While taking into account item 1.1, the WCA and Community members shall be responsible for promoting Code of Conduct awareness and education among Community members; in particular WCA Volunteers.
 2. **Conduct**
    1. Every Community member must behave with respect towards the representatives of the WCA, other Registered Speedcubers, spectators, press and partners. This applies to behavior during WCA Competitions and also online, on official WCA platforms. Community members are expected to conduct themselves according to the following values:
       1. Compassion: treat others as you would like to be treated.

--- a/documents/WCA Bylaws.md
+++ b/documents/WCA Bylaws.md
@@ -24,7 +24,7 @@ Our values are Community, Fairness, Fun, Excellence and Volunteerism.
 Application for membership, as defined in Section 5056 of the California Nonprofit Public Benefit Corporation Law, as amended (the “Nonprofit Corporation Law”), shall be open to any person. Membership is granted after completion and receipt of a membership application and annual dues. All memberships shall be granted upon a recommendation of a member and a majority vote of the board, or a majority vote of members at a properly announced meeting. Membership is non-transferrable.
 
 ### 2.2 Types of Membership
-The WCA shall offer the following type of memberships to its organization:
+The WCA shall offer the following types of memberships to its organization:
 
 1. Regional Organizations;
 2. Associate Regional Organizations;
@@ -43,10 +43,10 @@ Regional Organization membership is available for registered entities who act to
 5. The Regional Organization provides a description of their organizational structure;
 6. The Regional Organization provides a clear description of the area they cover along with a report on past activities proving they act as the entity which organises WCA activities within their region.
   
-This membership is active from the moment they are acknowledged by the Board of Directors as meeting the requirements for this category and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9). This category of members do not have the right to vote in matters of the WCA and any elections.
+This membership is active from the moment they are acknowledged by the Board of Directors as meeting the requirements for this category and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9). This category of members does not have the right to vote in matters of the WCA and any elections.
 
 ### 2.4 Associate Regional Organization Membership
-Associate Regional Organization membership is available for groups who act to organize WCA activities within their specified regions but however, are not currently a registered entity within the region in which they operate. Applications for this type of membership are to be made in writing to the Board of Directors provided the entity meets the following requirements:
+Associate Regional Organization membership is available for groups who act to organize WCA activities within their specified regions but are not currently a registered entity within the region in which they operate. Applications for this type of membership are to be made in writing to the Board of Directors provided the entity meets the following requirements:
 
 1. The Associate Regional Organization has a name, address and contact details;
 2. The Associate Regional Organization has a website and a logo;
@@ -54,10 +54,10 @@ Associate Regional Organization membership is available for groups who act to or
 4. The Associate Regional Organization provides a description of their organizational structure;
 5. The Associate Regional Organization provides a clear description of the area they cover along with a report on past activities proving they act as the entity which organises WCA activities within their region.
 
-This membership is active from the moment they are acknowledged by the Board of Directors as meeting the requirements for this category and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9) or after two years from the date in which their membership is active. This category of members do not have the right to vote in matters of the WCA and any elections.
+This membership is active from the moment they are acknowledged by the Board of Directors as meeting the requirements for this category and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9) or after two years from the date in which their membership is active. This category of members does not have the right to vote in matters of the WCA and any elections.
 
 ### 2.5 Individual Voting Members
-Any individual who is currently a Full Delegate, Committee/Team Leader, Committee/Team Senior Member, director or officer is automatically considered an individual voting member of the WCA. This membership is active from the moment an individual is promoted to one of the above positions and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9). This category of members have the right to place a maximum of one vote in matters of the WCA and any elections.
+Any individual who is currently a Full Delegate, Committee/Team Leader, Committee/Team Senior Member, director or officer is automatically considered an individual voting member of the WCA. This membership is active from the moment an individual is promoted to one of the above positions and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9). This category of members has the right to place a maximum of one vote in matters of the WCA and any elections.
 
 ### 2.6 Individual Non-voting Members
 Any individual who has competed at a past WCA Competition and has an attributed personal WCA ID is automatically considered an individual non-voting member of the WCA. This membership type is active from the moment an individual starts their first official attempt at their first WCA competition and continues until this membership is revoked either through resignation or termination (see 2.7 and 2.9). This category of members does not have the right to vote in matters of the WCA and any elections.
@@ -72,7 +72,7 @@ Each voting member shall be eligible to appoint in writing one voting representa
 Any member may resign by filing a written resignation with the Secretary. Resignation shall not relieve a member of unpaid dues, or other charges previously accrued. A member can have their membership terminated by a majority vote of the membership, or by a supermajority (⅔) vote of the Board.
 
 ### 2.10 Annual Meetings
-An annual meeting of the members shall take place no later than 10 months after the end of the fiscal year, the specific date, time, and location of which will be designated by the chair. The annual meeting shall run according to the following agenda which must be circulated to the members not less than 2 weeks prior to the meeting:
+An annual meeting of the members shall take place no later than 10 months after the end of the fiscal year, the specific date, time, and location of which will be designated by the Chair. The annual meeting shall run according to the following agenda which must be circulated to the members not less than 2 weeks prior to the meeting:
 
 1. Opening of the meeting;
 2. Roll call;

--- a/documents/policies/external/Competition Requirements.md
+++ b/documents/policies/external/Competition Requirements.md
@@ -50,7 +50,7 @@ An official WCA Competition must:
    3. The competition website may acknowledge the sponsorship contribution.
    4. WCA competitions must only collaborate with:
       1. Local Organizing Support (e.g., ROs, clubs, university groups),
-      2. Standard Sponsors (e.g., vendors/brands), provided their sponsorship material do not promote competing speedcubing leagues or alternative governing bodies,
+      2. Standard Sponsors (e.g., vendors/brands), provided their sponsorship materials do not promote competing speedcubing leagues or alternative governing bodies,
       3. Dependent Data Services that use public WCA results for non-governance rankings, or
       4. Entities explicitly approved by the WCA Board.
 10. Competitions with proceeds going to a charity must indicate so on the competition website, preferably in the Information section of the 'General info' tab. The name of the charity must be included. Any such charity needs to be recognized in the country where the competition is held.
@@ -210,7 +210,7 @@ The WCA Delegate must submit the following information when requesting approval 
       2. Other events may only be held unofficially.
    3. The winner of the main event of the competition should be considered the overall winner of the competition.
          1. The main event of the competition should be publicly mentioned on the competition website.
-         2. The main event should be recognizable in the competition schedule and having an appropriate proportion of rounds and attempts.
+         2. The main event should be recognizable in the competition schedule and have an appropriate proportion of rounds and attempts.
          3. The main event winner should be announced as the overall winner of the competition
          4. Only WCA sanctioned events may be considered the main event of the competition.
          5. There may be no main event of the competition.


### PR DESCRIPTION
## Summary
Grammar and agreement corrections; no change in meaning.

### `documents/WCA Bylaws.md`
- §2.2 "the following **type** of memberships" → "**types** of memberships" (four types are listed)
- §2.4 "but **however,** are not currently" → "but are not currently" (redundant pairing)
- §2.3/§2.5 subject–verb agreement: "This category of members **do not** have / **have**" → "**does not** have / **has**". The singular subject "This category of members" already takes the singular verb in §2.6 — this aligns the other three occurrences with it.
- §2.10 "designated by **the chair**" → "**the Chair**" (defined term in §6.1)

### `documents/policies/external/Competition Requirements.md`
- "their sponsorship **material do** not promote" → "**materials do** not promote"
- "recognizable in the competition schedule **and having** an appropriate proportion" → "**and have**" (parallel with "be recognizable")

### `documents/Code of Conduct.md`
- "While taking into account **Article 1.1**" → "**item 1.1**" (this document is structured as numbered items, not Articles)
- "education **amongst**" → "**among**" (American spelling used throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)