### PR TITLE
Fixed table and images in Organizer Handbook

### DIFF
--- a/edudoc/organizer-handbook/organizer-handbook.md
+++ b/edudoc/organizer-handbook/organizer-handbook.md
@@ -165,55 +165,71 @@ Delegates are highly experienced Community members and often help out as organiz
 <table>
   <thead>
     <tr>
-      <th><strong>Delegate Duties</strong></th>
-      <th><strong>Organizer Duties</strong></th>
+      <th>
+        <strong>Delegate Duties</strong>
+      </th>
+      <th>
+        <strong>Organizer Duties</strong>
+      </th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td><strong>Before the competition:</strong></br>
+      <td>
+        <strong>Before the competition:</strong>
         <ul>
           <li>Submitting the competition page</li>
           <li>Assisting Organizers</li>
           <li>Ensuring WCA Policies are followed</li>
           <li>Generating scrambles</li>
-      <td><strong>Before the competition:</strong></li>
+        </ul>
+      </td>
+      <td>
+        <strong>Before the competition:</strong>
         <ul>
           <li>Making the competition page</li>
           <li>Securing a venue</li>
-          <li>Arranging equipment (e.g. timers, mats, scoresheets, puzzle covers, etc.)</li>
-          <li>Generating groups and assigning volunteer duties</br></li>
+          <li>Arranging equipment (e.g. timers, mats, score sheets, puzzle covers, etc.)</li>
+          <li>Generating groups and assigning volunteer duties</li>
         </ul>
+      </td>
     </tr>
     <tr>
-      <td><strong>During the competition:</strong></br>
+      <td>
+        <strong>During the competition:</strong>
         <ul>
           <li>Ensuring that the competition follows WCA Regulations and WCA Policies</li>
           <li>Double-checking entered results</li>
         </ul>
       </td>
-      <td><strong>During the competition:</strong></br>
+      <td>
+        <strong>During the competition:</strong>
         <ul>
           <li>Giving the first-time competitor tutorial</li>
           <li>Making announcements</li>
           <li>Finding volunteers as needed</li>
           <li>Collecting and putting out score sheets</li>
           <li>Keeping the competition running smoothly</li>
-        </td>
+        </ul>
+      </td>
     </tr>
     <tr>
-      <td><strong>After the competition:</strong></br>
+      <td>
+        <strong>After the competition:</strong>
         <ul>
           <li>Providing feedback to Community organizers</li>
           <li>Ensuring WCA Policies are followed</li>
           <li>Submitting the competition results</li>
           <li>Writing and submitting the Delegate Report</li>
         </ul>
-      <td><strong>After the competition:</strong></br>
+      </td>
+      <td>
+        <strong>After the competition:</strong>
         <ul>
           <li>Submitting any expenses</li>
           <li>Self-reflecting on feedback provided by Delegates</li>
         </ul>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/edudoc/organizer-handbook/organizer-handbook.md
+++ b/edudoc/organizer-handbook/organizer-handbook.md
@@ -632,7 +632,7 @@ If you require competitors to pay the registration fee in advance, the organizat
 Here is an example budget. If your net profit is negative, adjust your expenses and income to avoid significant financial loss. For a more complete list of possible expenses, see the budget section of the [competition checklist](https://docs.google.com/spreadsheets/d/1i5QStai9sJSrST2EUPBNwfejI0QeW3ojDJ9Ok-GpFCY/copy).
 
 ::::: {.box .example .text-left}
-[](images/budget.png){.centered width=50%}
+![](images/budget.png){.centered width=50%}
 :::::
 
 ### Setting the Registration Fee
@@ -951,7 +951,7 @@ If you print the score sheets yourself, you will need to cut them yourself. If y
 Score sheets are typically arranged with four sheets per page, sorted by quadrant. To cut them, follow Alexandre Ondet’s diagram below.
 
 ::::: {.box .example .text-left}
-[](images/cutting-scorecards.png){.centered width=50%}
+![](images/cutting-scorecards.png){.centered width=50%}
 :::::
 
 Before score sheets are cut, they might look to be out of order at first glance. Peek behind each score sheet and you should see a score sheet from the same group. This type of sorting can save a lot of time sifting through score sheets and reduce the likelihood of misplacing them.
@@ -965,7 +965,7 @@ Name tags are not only helpful for identifying which competitor is which, but th
 Here is an example name tag from Perfect Vision Provo 2020.
 
 ::::: {.box .example .text-left}
-[](images/lanyard.png){.centered width=50%}
+![](images/lanyard.png){.centered width=50%}
 :::::
 
 ### Other Printables

--- a/edudoc/organizer-handbook/organizer-handbook.md
+++ b/edudoc/organizer-handbook/organizer-handbook.md
@@ -951,7 +951,7 @@ If you print the score sheets yourself, you will need to cut them yourself. If y
 Score sheets are typically arranged with four sheets per page, sorted by quadrant. To cut them, follow Alexandre Ondet’s diagram below.
 
 ::::: {.box .example .text-left}
-![](images/cutting-scorecards.png){.centered width=50%}
+![](images/cutting_scorecards.png){.centered width=50%}
 :::::
 
 Before score sheets are cut, they might look to be out of order at first glance. Peek behind each score sheet and you should see a score sheet from the same group. This type of sorting can save a lot of time sifting through score sheets and reduce the likelihood of misplacing them.


### PR DESCRIPTION
The HTML table was missing some tags that GitHub was okay with, but the PDF build was not. The images had the same syntax issue and one filename was incorrect.